### PR TITLE
tpm2_nvwrite: only print data on verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### next
+  * tpm2_nvlist: output in yaml format.
   * tpm2_makecredential format changes to the -o output file.
   * tpm2-quote: -o option removed.
   * tpm2_rsaencrypt: -I is now an argument and input defaults to stdin. -o is optional and

--- a/man/tpm2_nvlist.1.md
+++ b/man/tpm2_nvlist.1.md
@@ -14,7 +14,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-**tpm2_nvlist**(1) - display all defined Non-Volatile (NV)s indices to stdout.
+**tpm2_nvlist**(1) - display all defined Non-Volatile (NV)s indices to stdout in a YAML format.
 
 Display metadata for all defined NV indices. Metadata includes:
 
@@ -22,6 +22,29 @@ Display metadata for all defined NV indices. Metadata includes:
   * The hash algorithm used to compute the name of the index.
   * The auth policy.
   * The NV attributes as defined in section "NV Attributes".
+
+Example Output:
+```
+0x1500015:
+  hash algorithm:
+    friendly: sha256
+    value: 0xB
+  attributes:
+    friendly: ownerwrite|ownerread
+    value: 0x2000200
+  size: 32
+  authorization policy:
+
+0x1500017:
+  hash algorithm:
+    friendly: sha256
+    value: 0xB
+  attributes:
+    friendly: ownerwrite|ownerread
+    value: 0x2000200
+  size: 32
+  authorization policy:
+```
 
 # OPTIONS
 

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -69,7 +69,7 @@ static bool nv_list(TSS2_SYS_CONTEXT *sapi_context) {
 
     TPMI_YES_NO moreData;
     TPMS_CAPABILITY_DATA capabilityData;
-    UINT32 property = tpm2_util_endian_swap_32(TPM_HT_NV_INDEX);
+    UINT32 property = tpm2_util_hton_32(TPM_HT_NV_INDEX);
     TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_GetCapability(sapi_context, 0, TPM_CAP_HANDLES,
             property, TPM_PT_NV_INDEX_MAX, &moreData, &capabilityData, 0));
     if (rval != TPM_RC_SUCCESS) {


### PR DESCRIPTION
Only print the written data when -V is specified and print
the data in an xxd compatable hexdump.

Fixes: #605

Signed-off-by: William Roberts <william.c.roberts@intel.com>