### PR TITLE
log: fix verbose option

### DIFF
--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -119,6 +119,10 @@ int main(int argc, char *argv[], char *envp[]) {
         goto free_opts;
     }
 
+    if (flags.verbose) {
+        log_set_level(log_level_verbose);
+    }
+
     /*
      * We don't want a cyclic dependency between tools/options. Resolving those
      * works well on linux/elf based systems, but darwin and windows tend to


### PR DESCRIPTION
log_set_level() was never being called when verbose
was enabled. So set it when verbose is enabled.

This fixes LOG_INFO not showing up.

Signed-off-by: William Roberts <william.c.roberts@intel.com>