### PR TITLE
tpm2_errata: enable with -Z

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -252,12 +252,17 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv, char **envp,
 
     UNUSED(envp);
 
+    /*
+     * Handy way to *try* and find all used options:
+     * grep -rn case\ \'[a-zA-Z]\' | awk '{print $3}' | sed s/\'//g | sed s/\://g | sort | uniq | less
+     */
     struct option long_options [] = {
-        { "tcti",    required_argument, NULL, 'T' },
-        { "help",    no_argument,       NULL, 'h' },
-        { "verbose", no_argument,       NULL, 'v' },
-        { "quiet",   no_argument,       NULL, 'Q' },
-        { "version", no_argument,       NULL, 'V' },
+        { "tcti",           required_argument, NULL, 'T' },
+        { "help",           no_argument,       NULL, 'h' },
+        { "verbose",        no_argument,       NULL, 'v' },
+        { "quiet",          no_argument,       NULL, 'Q' },
+        { "version",        no_argument,       NULL, 'V' },
+        { "enable-errata", no_argument,        NULL, 'Z' },
     };
 
     char *tcti_opts = NULL;
@@ -266,7 +271,7 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv, char **envp,
     tcti_name = env_str ? env_str : tcti_name;
 
     /* handle any options */
-    tpm2_options *opts = tpm2_options_new("T:hvVQ",
+    tpm2_options *opts = tpm2_options_new("T:hvVQZ",
             ARRAY_LEN(long_options), long_options, NULL, NULL);
     if (!opts) {
         return tpm2_option_code_err;
@@ -306,6 +311,9 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv, char **envp,
             show_version(argv[0]);
             rc = tpm2_option_code_stop;
             goto out;
+            break;
+        case 'Z':
+            flags->enable_errata = 1;
             break;
         case ':':
             LOG_ERR("Argument %c needs a value!", optopt);

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -46,7 +46,7 @@ union tpm2_option_flags {
     struct {
         UINT8 verbose : 1;
         UINT8 quiet   : 1;
-        UINT8 unused  : 6;
+        UINT8 enable_errata  : 1;
     };
     UINT8 all;
 };

--- a/man/common/options.md
+++ b/man/common/options.md
@@ -16,3 +16,7 @@ information that many users may expect.
 
   * **-Q**, **--quiet**:
     Silence normal tool output to stdout.
+
+  * **-Z**, **--enable-errata**:
+    Enable the application of errata fixups. Useful if an errata fixup needs to be
+    applied to commands sent to the TPM.

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -139,7 +139,9 @@ int main(int argc, char *argv[], char *envp[]) {
     /* TODO SAPI INIT */
     TSS2_SYS_CONTEXT *sapi_context = sapi_ctx_init(tcti);
 
-    tpm2_errata_init(sapi_context);
+    if (flags.enable_errata) {
+        tpm2_errata_init(sapi_context);
+    }
 
     /*
      * Call the specific tool, all tools implement this function instead of


### PR DESCRIPTION
Disable the application of errata fixups by default and require the user to enable them.

Fixes #622

Signed-off-by: William Roberts <william.c.roberts@intel.com>