### PR TITLE
Switch to new TPMA layout of tpm2-tss

### DIFF
--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -66,147 +66,147 @@ struct dispatch_table {
 static bool authread(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_AUTHREAD = 1;
+    *nv |= TPMA_NV_TPMA_NV_AUTHREAD;
     return true;
 }
 
 static bool authwrite(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_AUTHWRITE = 1;
+    *nv |= TPMA_NV_TPMA_NV_AUTHWRITE;
     return true;
 }
 
 static bool clear_stclear(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_CLEAR_STCLEAR = 1;
+    *nv |= TPMA_NV_TPMA_NV_CLEAR_STCLEAR;
     return true;
 }
 
 static bool globallock(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_GLOBALLOCK = 1;
+    *nv |= TPMA_NV_TPMA_NV_GLOBALLOCK;
     return true;
 }
 
 static bool no_da(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_NO_DA = 1;
+    *nv |= TPMA_NV_TPMA_NV_NO_DA;
     return true;
 }
 
 static bool orderly(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_ORDERLY = 1;
+    *nv |= TPMA_NV_TPMA_NV_ORDERLY;
     return true;
 }
 
 static bool ownerread(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_OWNERREAD = 1;
+    *nv |= TPMA_NV_TPMA_NV_OWNERREAD;
     return true;
 }
 
 static bool ownerwrite(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_OWNERWRITE = 1;
+    *nv |= TPMA_NV_TPMA_NV_OWNERWRITE;
     return true;
 }
 
 static bool platformcreate(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_PLATFORMCREATE = 1;
+    *nv |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
     return true;
 }
 
 static bool policyread(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_POLICYREAD = 1;
+    *nv |= TPMA_NV_TPMA_NV_POLICYREAD;
     return true;
 }
 
 static bool policywrite(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_POLICYWRITE = 1;
+    *nv |= TPMA_NV_TPMA_NV_POLICYWRITE;
     return true;
 }
 
 static bool policydelete(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_POLICY_DELETE = 1;
+    *nv |= TPMA_NV_TPMA_NV_POLICY_DELETE;
     return true;
 }
 
 static bool ppread(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_PPREAD = 1;
+    *nv |= TPMA_NV_TPMA_NV_PPREAD;
     return true;
 }
 
 static bool ppwrite(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_PPWRITE = 1;
+    *nv |= TPMA_NV_TPMA_NV_PPWRITE;
     return true;
 }
 
 static bool readlocked(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_READLOCKED = 1;
+    *nv |= TPMA_NV_TPMA_NV_READLOCKED;
     return true;
 }
 
 static bool read_stclear(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_READ_STCLEAR = 1;
+    *nv |= TPMA_NV_TPMA_NV_READ_STCLEAR;
     return true;
 }
 
 static bool writeall(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_WRITEALL = 1;
+    *nv |= TPMA_NV_TPMA_NV_WRITEALL;
     return true;
 }
 
 static bool writedefine(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_WRITEDEFINE = 1;
+    *nv |= TPMA_NV_TPMA_NV_WRITEDEFINE;
     return true;
 }
 
 static bool writelocked(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_WRITELOCKED = 1;
+    *nv |= TPMA_NV_TPMA_NV_WRITELOCKED;
     return true;
 }
 
 static bool write_stclear(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_WRITE_STCLEAR = 1;
+    *nv |= TPMA_NV_TPMA_NV_WRITE_STCLEAR;
     return true;
 }
 
 static bool written(TPMA_NV *nv, char *arg) {
 
     UNUSED(arg);
-    nv->TPMA_NV_WRITTEN = 1;
+    *nv |= TPMA_NV_TPMA_NV_WRITTEN;
     return true;
 }
 
@@ -226,7 +226,8 @@ static bool nt(TPMA_NV *nv, char *arg) {
         return false;
     }
 
-    nv->TPM2_NT = value;
+    *nv &= ~TPMA_NV_TPM2_NT;
+    *nv |= value << 4;
     return true;
 }
 
@@ -277,77 +278,77 @@ static dispatch_table nv_attr_table[] = { // Bit Index
 static bool fixedtpm(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    obj->fixedTPM = 1;
+    *obj |= TPMA_OBJECT_FIXEDTPM;
     return true;
 }
 
 static bool stclear(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    obj->stClear = 1;
+    *obj |= TPMA_OBJECT_STCLEAR;
     return true;
 }
 
 static bool fixedparent(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    obj->fixedParent = 1;
+    *obj |= TPMA_OBJECT_FIXEDPARENT;
     return true;
 }
 
 static bool sensitivedataorigin(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    obj->sensitiveDataOrigin = 1;
+    *obj |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
     return true;
 }
 
 static bool userwithauth(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    obj->userWithAuth = 1;
+    *obj |= TPMA_OBJECT_USERWITHAUTH;
     return true;
 }
 
 static bool adminwithpolicy(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    obj->adminWithPolicy = 1;
+    *obj |= TPMA_OBJECT_ADMINWITHPOLICY;
     return true;
 }
 
 static bool noda(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    obj->noDA = 1;
+    *obj |= TPMA_OBJECT_NODA;
     return true;
 }
 
 static bool encryptedduplication(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    obj->encryptedDuplication = 1;
+    *obj |= TPMA_OBJECT_ENCRYPTEDDUPLICATION;
     return true;
 }
 
 static bool restricted(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    obj->restricted = 1;
+    *obj |= TPMA_OBJECT_RESTRICTED;
     return true;
 }
 
 static bool decrypt(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    obj->decrypt = 1;
+    *obj |= TPMA_OBJECT_DECRYPT;
     return true;
 }
 
 static bool sign(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    obj->sign = 1;
+    *obj |= TPMA_OBJECT_SIGN;
     return true;
 }
 
@@ -626,16 +627,16 @@ static char *tpm2_attr_util_common_attrtostr(UINT32 attrs, dispatch_table *table
 }
 
 char *tpm2_attr_util_nv_attrtostr(TPMA_NV nvattrs) {
-    return tpm2_attr_util_common_attrtostr(nvattrs.val, nv_attr_table, ARRAY_LEN(nv_attr_table));
+    return tpm2_attr_util_common_attrtostr(nvattrs, nv_attr_table, ARRAY_LEN(nv_attr_table));
 }
 
 char *tpm2_attr_util_obj_attrtostr(TPMA_OBJECT objattrs) {
-    return tpm2_attr_util_common_attrtostr(objattrs.val, obj_attr_table, ARRAY_LEN(obj_attr_table));
+    return tpm2_attr_util_common_attrtostr(objattrs, obj_attr_table, ARRAY_LEN(obj_attr_table));
 }
 
 bool tpm2_attr_util_obj_from_optarg(char *argvalue, TPMA_OBJECT *objattrs) {
 
-    bool res = tpm2_util_string_to_uint32(argvalue, &objattrs->val);
+    bool res = tpm2_util_string_to_uint32(argvalue, objattrs);
     if (!res) {
         res = tpm2_attr_util_obj_strtoattr(argvalue, objattrs);
     }

--- a/lib/tpm2_errata.c
+++ b/lib/tpm2_errata.c
@@ -225,7 +225,7 @@ static void fixup_sign_decrypt_attribute_encoding(va_list *ap) {
 
     TPMA_OBJECT *attrs = va_arg(*ap, TPMA_OBJECT *);
 
-    attrs->sign = 0;
+    *attrs &= ~TPMA_OBJECT_SIGN;
 }
 
 static bool errata_match(struct tpm2_errata_desc *errata) {

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -54,12 +54,11 @@
                 .userAuth.size = 0, \
             }, \
     }
-#define SESSION_ATTRIBUTES_INIT(mask) { .val = mask }
 
 #define TPMS_AUTH_COMMAND_INIT(session_handle) { \
         .sessionHandle = session_handle,\
 	    .nonce = TPM2B_EMPTY_INIT, \
-	    .sessionAttributes = { .val = 0 }, \
+	    .sessionAttributes = 0, \
 	    .hmac = TPM2B_EMPTY_INIT \
     }
 

--- a/lib/tpm_hash.c
+++ b/lib/tpm_hash.c
@@ -95,7 +95,7 @@ TSS2_RC tpm_hash_file(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH halg,
 
     TPMS_AUTH_COMMAND cmdAuth = { .sessionHandle = TPM2_RS_PW, .nonce =
             TPM2B_EMPTY_INIT, .hmac = TPM2B_EMPTY_INIT, .sessionAttributes =
-            SESSION_ATTRIBUTES_INIT(0), };
+            0, };
     TPMS_AUTH_COMMAND *cmdSessionArray[1] = { &cmdAuth };
     TSS2_SYS_CMD_AUTHS cmdAuthArray = { 1, &cmdSessionArray[0] };
 

--- a/lib/tpm_hmac.c
+++ b/lib/tpm_hmac.c
@@ -50,8 +50,8 @@ static UINT32 LoadExternalHMACKey(TSS2_SYS_CONTEXT *sapi_contex, TPMI_ALG_HASH h
     inPublic.publicArea.type = TPM2_ALG_KEYEDHASH;
     inPublic.publicArea.nameAlg = TPM2_ALG_NULL;
     *( UINT32 *)&( inPublic.publicArea.objectAttributes )= 0;
-    inPublic.publicArea.objectAttributes.sign = 1;
-    inPublic.publicArea.objectAttributes.userWithAuth = 1;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_SIGN;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
     inPublic.publicArea.authPolicy.size = 0;
     inPublic.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM2_ALG_HMAC;
     inPublic.publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg = hashAlg;
@@ -76,7 +76,7 @@ TSS2_RC tpm_hmac(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH hashAlg, TPM2B *k
             .nonce = {
                     .size = 0,
             },
-            .sessionAttributes = { .val = 0 },
+            .sessionAttributes = 0,
 
 
     };

--- a/test/unit/test_tpm2_errata.c
+++ b/test/unit/test_tpm2_errata.c
@@ -83,9 +83,7 @@ TSS2_RC __wrap_Tss2_Sys_GetCapability(TSS2_SYS_CONTEXT *sysContext,
 
 #define TPM2B_PUBLIC_INIT(value) { \
     .publicArea = { \
-        .objectAttributes = { \
-            .val = value \
-         } \
+        .objectAttributes = value \
     } \
 }
 
@@ -98,8 +96,8 @@ static void test_tpm2_errata_no_init_and_apply(void **state) {
     tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
                       &in_public.publicArea.objectAttributes);
 
-    assert_int_equal(in_public.publicArea.objectAttributes.sign, 1);
-
+    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN,
+                    TPMA_OBJECT_SIGN);
 }
 
 static void test_tpm2_errata_bad_init_and_apply(void **state) {
@@ -114,8 +112,8 @@ static void test_tpm2_errata_bad_init_and_apply(void **state) {
     tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
                       &in_public.publicArea.objectAttributes);
 
-    assert_int_equal(in_public.publicArea.objectAttributes.sign, 1);
-
+    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN,
+                    TPMA_OBJECT_SIGN);
 }
 
 static void test_tpm2_errata_init_good_and_apply(void **state) {
@@ -129,7 +127,8 @@ static void test_tpm2_errata_init_good_and_apply(void **state) {
     tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
                       &in_public.publicArea.objectAttributes);
 
-    assert_int_equal(in_public.publicArea.objectAttributes.sign, 0);
+    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN,
+                     0);
 }
 
 static void test_tpm2_errata_init_good_and_no_match(void **state) {
@@ -144,7 +143,8 @@ static void test_tpm2_errata_init_good_and_no_match(void **state) {
     tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
                       &in_public.publicArea.objectAttributes);
 
-    assert_int_equal(in_public.publicArea.objectAttributes.sign, 1);
+    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN,
+                    TPMA_OBJECT_SIGN);
 }
 
 static void test_tpm2_errata_init_no_match_and_apply(void **state) {
@@ -160,7 +160,8 @@ static void test_tpm2_errata_init_no_match_and_apply(void **state) {
     tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
                       &in_public.publicArea.objectAttributes);
 
-    assert_int_equal(in_public.publicArea.objectAttributes.sign, 1);
+    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN,
+                    TPMA_OBJECT_SIGN);
 }
 
 int main(int argc, char *argv[]) {

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -157,7 +157,7 @@ static bool activate_credential_and_output(TSS2_SYS_CONTEXT *sapi_context) {
             .nonce = { .size = 0 },
             .hmac =  { .size = 0 },
             .sessionHandle = 0,
-            .sessionAttributes = { .val = 0 },
+            .sessionAttributes = 0,
     };
 
     ctx.password.sessionHandle = TPM2_RS_PW;
@@ -206,7 +206,7 @@ static bool activate_credential_and_output(TSS2_SYS_CONTEXT *sapi_context) {
     }
 
     tmp_auth.sessionHandle = session->sessionHandle;
-    tmp_auth.sessionAttributes.continueSession = 1;
+    tmp_auth.sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
     tmp_auth.hmac.size = 0;
 
     rval = TSS2_RETRY_EXP(Tss2_Sys_ActivateCredential(sapi_context, ctx.handle.activate,

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -70,11 +70,10 @@ struct tpm_createprimary_ctx {
 #define PUBLIC_AREA_TPMA_OBJECT_DEFAULT_INIT { \
     .publicArea = { \
         .type = TPM2_ALG_RSA, \
-        .objectAttributes = { \
-            .val = TPMA_OBJECT_RESTRICTED|TPMA_OBJECT_DECRYPT \
+        .objectAttributes = \
+            TPMA_OBJECT_RESTRICTED|TPMA_OBJECT_DECRYPT \
             |TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT \
             |TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH \
-        }, \
     }, \
 }
 
@@ -83,7 +82,7 @@ static tpm_createprimary_ctx ctx = {
         .sessionHandle = TPM2_RS_PW,
         .nonce = TPM2B_EMPTY_INIT,
         .hmac = TPM2B_EMPTY_INIT,
-        .sessionAttributes = SESSION_ATTRIBUTES_INIT(0),
+        .sessionAttributes = 0,
     },
     .inSensitive = TPM2B_SENSITIVE_CREATE_EMPTY_INIT,
     .in_public = PUBLIC_AREA_TPMA_OBJECT_DEFAULT_INIT,
@@ -180,7 +179,7 @@ int create_primary(TSS2_SYS_CONTEXT *sapi_context) {
 
     if(setup_alg())
         return -1;
-    tpm2_tool_output("ObjectAttribute: 0x%08X\n", ctx.in_public.publicArea.objectAttributes.val);
+    tpm2_tool_output("ObjectAttribute: 0x%08X\n", ctx.in_public.publicArea.objectAttributes);
 
     creationPCR.count = 0;
 

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -196,10 +196,10 @@ get_uint32_as_chars (UINT32    value,
 void
 tpm2_tool_output_tpma_modes (TPMA_MODES    modes)
 {
-    tpm2_tool_output ("TPM2_PT_MODES: 0x%08x\n", modes.val);
-    if (modes.FIPS_140_2)
+    tpm2_tool_output ("TPM2_PT_MODES: 0x%08x\n", modes);
+    if (modes & TPMA_MODES_FIPS_140_2)
         tpm2_tool_output ("  TPMA_MODES_FIPS_140_2\n");
-    if (modes.reserved1)
+    if (modes & TPMA_MODES_RESERVED1)
         tpm2_tool_output ("  TPMA_MODES_RESERVED1 (these bits shouldn't be set)\n");
 }
 /*
@@ -209,14 +209,14 @@ void
 dump_permanent_attrs (TPMA_PERMANENT attrs)
 {
     tpm2_tool_output ("TPM2_PT_PERSISTENT:\n");
-    tpm2_tool_output ("  ownerAuthSet:              %s\n", prop_str (attrs.ownerAuthSet));
-    tpm2_tool_output ("  endorsementAuthSet:        %s\n", prop_str (attrs.endorsementAuthSet));
-    tpm2_tool_output ("  lockoutAuthSet:            %s\n", prop_str (attrs.lockoutAuthSet));
-    tpm2_tool_output ("  reserved1:                 %s\n", prop_str (attrs.reserved1));
-    tpm2_tool_output ("  disableClear:              %s\n", prop_str (attrs.disableClear));
-    tpm2_tool_output ("  inLockout:                 %s\n", prop_str (attrs.inLockout));
-    tpm2_tool_output ("  tpmGeneratedEPS:           %s\n", prop_str (attrs.tpmGeneratedEPS));
-    tpm2_tool_output ("  reserved2:                 %s\n", prop_str (attrs.reserved2));
+    tpm2_tool_output ("  ownerAuthSet:              %s\n", prop_str (attrs & TPMA_PERMANENT_OWNERAUTHSET));
+    tpm2_tool_output ("  endorsementAuthSet:        %s\n", prop_str (attrs & TPMA_PERMANENT_ENDORSEMENTAUTHSET));
+    tpm2_tool_output ("  lockoutAuthSet:            %s\n", prop_str (attrs & TPMA_PERMANENT_LOCKOUTAUTHSET));
+    tpm2_tool_output ("  reserved1:                 %s\n", prop_str (attrs & TPMA_PERMANENT_RESERVED1));
+    tpm2_tool_output ("  disableClear:              %s\n", prop_str (attrs & TPMA_PERMANENT_DISABLECLEAR));
+    tpm2_tool_output ("  inLockout:                 %s\n", prop_str (attrs & TPMA_PERMANENT_INLOCKOUT));
+    tpm2_tool_output ("  tpmGeneratedEPS:           %s\n", prop_str (attrs & TPMA_PERMANENT_TPMGENERATEDEPS));
+    tpm2_tool_output ("  reserved2:                 %s\n", prop_str (attrs & TPMA_PERMANENT_RESERVED2));
 }
 /*
  * Print string representations of the TPMA_STARTUP_CLEAR attributes.
@@ -225,12 +225,12 @@ void
 dump_startup_clear_attrs (TPMA_STARTUP_CLEAR attrs)
 {
     tpm2_tool_output ("TPM2_PT_STARTUP_CLEAR:\n");
-    tpm2_tool_output ("  phEnable:                  %s\n", prop_str (attrs.phEnable));
-    tpm2_tool_output ("  shEnable:                  %s\n", prop_str (attrs.shEnable));
-    tpm2_tool_output ("  ehEnable:                  %s\n", prop_str (attrs.ehEnable));
-    tpm2_tool_output ("  phEnableNV:                %s\n", prop_str (attrs.phEnableNV));
-    tpm2_tool_output ("  reserved1:                 %s\n", prop_str (attrs.reserved1));
-    tpm2_tool_output ("  orderly:                   %s\n", prop_str (attrs.orderly));
+    tpm2_tool_output ("  phEnable:                  %s\n", prop_str (attrs & TPMA_STARTUP_CLEAR_PHENABLE));
+    tpm2_tool_output ("  shEnable:                  %s\n", prop_str (attrs & TPMA_STARTUP_CLEAR_SHENABLE));
+    tpm2_tool_output ("  ehEnable:                  %s\n", prop_str (attrs & TPMA_STARTUP_CLEAR_EHENABLE));;
+    tpm2_tool_output ("  phEnableNV:                %s\n", prop_str (attrs & TPMA_STARTUP_CLEAR_PHENABLENV));
+    tpm2_tool_output ("  reserved1:                 %s\n", prop_str (attrs & TPMA_STARTUP_CLEAR_RESERVED1));
+    tpm2_tool_output ("  orderly:                   %s\n", prop_str (attrs & TPMA_STARTUP_CLEAR_ORDERLY));
 }
 /*
  * Iterate over all fixed properties, call the unique print function for each.
@@ -502,14 +502,14 @@ dump_algorithm_properties (TPM2_ALG_ID       id,
     id_name = id_name ? id_name : "unknown";
 
     tpm2_tool_output ("TPMA_ALGORITHM for ALG_ID: 0x%x - %s\n", id, id_name);
-    tpm2_tool_output ("  asymmetric: %s\n", prop_str (alg_attrs.asymmetric));
-    tpm2_tool_output ("  symmetric:  %s\n", prop_str (alg_attrs.symmetric));
-    tpm2_tool_output ("  hash:       %s\n", prop_str (alg_attrs.hash));
-    tpm2_tool_output ("  object:     %s\n", prop_str (alg_attrs.object));
-    tpm2_tool_output ("  reserved:   0x%x\n", alg_attrs.reserved1);
-    tpm2_tool_output ("  signing:    %s\n", prop_str (alg_attrs.signing));
-    tpm2_tool_output ("  encrypting: %s\n", prop_str (alg_attrs.encrypting));
-    tpm2_tool_output ("  method:     %s\n", prop_str (alg_attrs.method));
+    tpm2_tool_output ("  asymmetric: %s\n", prop_str (alg_attrs & TPMA_ALGORITHM_ASYMMETRIC));
+    tpm2_tool_output ("  symmetric:  %s\n", prop_str (alg_attrs & TPMA_ALGORITHM_SYMMETRIC));
+    tpm2_tool_output ("  hash:       %s\n", prop_str (alg_attrs & TPMA_ALGORITHM_HASH));
+    tpm2_tool_output ("  object:     %s\n", prop_str (alg_attrs & TPMA_ALGORITHM_OBJECT));
+    tpm2_tool_output ("  reserved:   0x%x\n", (alg_attrs & TPMA_ALGORITHM_RESERVED1) >> 4);
+    tpm2_tool_output ("  signing:    %s\n", prop_str (alg_attrs & TPMA_ALGORITHM_SIGNING));
+    tpm2_tool_output ("  encrypting: %s\n", prop_str (alg_attrs & TPMA_ALGORITHM_ENCRYPTING));
+    tpm2_tool_output ("  method:     %s\n", prop_str (alg_attrs & TPMA_ALGORITHM_METHOD));
 }
 
 /*
@@ -660,17 +660,17 @@ static const char *cc_to_str(UINT32 cc) {
 void
 dump_command_attrs (TPMA_CC tpma_cc)
 {
-    tpm2_tool_output ("TPMA_CC: 0x%08x\n", tpma_cc.val);
-    tpm2_tool_output ("  name: %s\n", cc_to_str(tpma_cc.commandIndex));
-    tpm2_tool_output ("  commandIndex: 0x%x\n", tpma_cc.commandIndex);
-    tpm2_tool_output ("  reserved1:    0x%x\n", tpma_cc.reserved1);
-    tpm2_tool_output ("  nv:           %s\n",   prop_str (tpma_cc.nv));
-    tpm2_tool_output ("  extensive:    %s\n",   prop_str (tpma_cc.extensive));
-    tpm2_tool_output ("  flushed:      %s\n",   prop_str (tpma_cc.flushed));
-    tpm2_tool_output ("  cHandles:     0x%x\n", tpma_cc.cHandles);
-    tpm2_tool_output ("  rHandle:      %s\n",   prop_str (tpma_cc.rHandle));
-    tpm2_tool_output ("  V:            %s\n",   prop_str (tpma_cc.V));
-    tpm2_tool_output ("  Res:          0x%x\n", tpma_cc.Res);
+    tpm2_tool_output ("TPMA_CC: 0x%08x\n", tpma_cc);
+    tpm2_tool_output ("  name: %s\n", cc_to_str(tpma_cc & TPMA_CC_COMMANDINDEX));
+    tpm2_tool_output ("  commandIndex: 0x%x\n", tpma_cc & TPMA_CC_COMMANDINDEX);
+    tpm2_tool_output ("  reserved1:    0x%x\n", (tpma_cc & TPMA_CC_RESERVED1) >> 16);
+    tpm2_tool_output ("  nv:           %s\n",   prop_str (tpma_cc & TPMA_CC_NV));
+    tpm2_tool_output ("  extensive:    %s\n",   prop_str (tpma_cc & TPMA_CC_EXTENSIVE));
+    tpm2_tool_output ("  flushed:      %s\n",   prop_str (tpma_cc & TPMA_CC_FLUSHED));
+    tpm2_tool_output ("  cHandles:     0x%x\n", tpma_cc & TPMA_CC_CHANDLES >>25);
+    tpm2_tool_output ("  rHandle:      %s\n",   prop_str (tpma_cc & TPMA_CC_RHANDLE));
+    tpm2_tool_output ("  V:            %s\n",   prop_str (tpma_cc & TPMA_CC_V));
+    tpm2_tool_output ("  Res:          0x%x\n", tpma_cc  & TPMA_CC_RES >>21);
 }
 /*
  * Iterate over an array of TPM2_ECC_CURVEs and dump out a human readable

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -86,15 +86,15 @@ BYTE authPolicy[] = {0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xB3, 0xF8,
 int set_key_algorithm(TPM2B_PUBLIC *inPublic) {
     inPublic->publicArea.nameAlg = TPM2_ALG_SHA256;
     // First clear attributes bit field.
-    *(UINT32 *)&(inPublic->publicArea.objectAttributes) = 0;
-    inPublic->publicArea.objectAttributes.restricted = 1;
-    inPublic->publicArea.objectAttributes.userWithAuth = 0;
-    inPublic->publicArea.objectAttributes.adminWithPolicy = 1;
-    inPublic->publicArea.objectAttributes.sign = 0;
-    inPublic->publicArea.objectAttributes.decrypt = 1;
-    inPublic->publicArea.objectAttributes.fixedTPM = 1;
-    inPublic->publicArea.objectAttributes.fixedParent = 1;
-    inPublic->publicArea.objectAttributes.sensitiveDataOrigin = 1;
+    inPublic->publicArea.objectAttributes = 0;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_RESTRICTED;
+    inPublic->publicArea.objectAttributes &= ~TPMA_OBJECT_USERWITHAUTH;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_ADMINWITHPOLICY;
+    inPublic->publicArea.objectAttributes &= ~TPMA_OBJECT_SIGN;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_FIXEDTPM;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_FIXEDPARENT;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
     inPublic->publicArea.authPolicy.size = 32;
     memcpy(inPublic->publicArea.authPolicy.buffer, authPolicy, 32);
 

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -79,15 +79,15 @@ static bool set_key_algorithm(TPM2B_PUBLIC *inPublic)
     inPublic->publicArea.nameAlg = TPM2_ALG_SHA256;
 
     // First clear attributes bit field.
-    *(UINT32 *) &(inPublic->publicArea.objectAttributes) = 0;
-    inPublic->publicArea.objectAttributes.restricted = 1;
-    inPublic->publicArea.objectAttributes.userWithAuth = 0;
-    inPublic->publicArea.objectAttributes.adminWithPolicy = 1;
-    inPublic->publicArea.objectAttributes.sign = 0;
-    inPublic->publicArea.objectAttributes.decrypt = 1;
-    inPublic->publicArea.objectAttributes.fixedTPM = 1;
-    inPublic->publicArea.objectAttributes.fixedParent = 1;
-    inPublic->publicArea.objectAttributes.sensitiveDataOrigin = 1;
+    inPublic->publicArea.objectAttributes = 0;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_RESTRICTED;
+    inPublic->publicArea.objectAttributes &= ~TPMA_OBJECT_USERWITHAUTH;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_ADMINWITHPOLICY;
+    inPublic->publicArea.objectAttributes &= ~TPMA_OBJECT_SIGN;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_FIXEDTPM;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_FIXEDPARENT;
+    inPublic->publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
     inPublic->publicArea.authPolicy.size = 32;
     memcpy(inPublic->publicArea.authPolicy.buffer, auth_policy, 32);
 
@@ -148,7 +148,7 @@ static bool create_ek_handle(TSS2_SYS_CONTEXT *sapi_context) {
         .sessionHandle = TPM2_RS_PW,
         .nonce = TPM2B_EMPTY_INIT,
         .hmac = TPM2B_EMPTY_INIT,
-        .sessionAttributes = SESSION_ATTRIBUTES_INIT(0),
+        .sessionAttributes = 0,
     };
 
     if (ctx.is_session_based_auth) {

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -274,13 +274,13 @@ static bool calc_sensitive_unique_data(void) {
 #define IMPORT_KEY_SYM_PUBLIC_AREA(X) \
     (X).publicArea.type = TPM2_ALG_SYMCIPHER; \
     (X).publicArea.nameAlg = TPM2_ALG_SHA256;\
-    (X).publicArea.objectAttributes.restricted = 0;\
-    (X).publicArea.objectAttributes.userWithAuth = 1;\
-    (X).publicArea.objectAttributes.decrypt = 1;\
-    (X).publicArea.objectAttributes.sign = 1;\
-    (X).publicArea.objectAttributes.fixedTPM = 0;\
-    (X).publicArea.objectAttributes.fixedParent = 0;\
-    (X).publicArea.objectAttributes.sensitiveDataOrigin = 0;\
+    (X).publicArea.objectAttributes &= ~TPMA_OBJECT_RESTRICTED;\
+    (X).publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;\
+    (X).publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;\
+    (X).publicArea.objectAttributes |= TPMA_OBJECT_SIGN;\
+    (X).publicArea.objectAttributes &= ~TPMA_OBJECT_FIXEDTPM;\
+    (X).publicArea.objectAttributes &= ~TPMA_OBJECT_FIXEDPARENT;\
+    (X).publicArea.objectAttributes &= ~TPMA_OBJECT_SENSITIVEDATAORIGIN;\
     (X).publicArea.authPolicy.size = 0;\
     (X).publicArea.parameters.symDetail.sym.algorithm = TPM2_ALG_AES;\
     (X).publicArea.parameters.symDetail.sym.keyBits.sym = 128;\
@@ -295,11 +295,11 @@ static bool create_import_key_public_data_and_name(void) {
                       &ctx.import_key_public.publicArea.objectAttributes);
 
     if (ctx.objectAttributes) {
-        ctx.import_key_public.publicArea.objectAttributes.val = ctx.objectAttributes;
+        ctx.import_key_public.publicArea.objectAttributes = ctx.objectAttributes;
     }
 
     tpm2_tool_output("ObjectAttribute: 0x%08X\n",
-                     ctx.import_key_public.publicArea.objectAttributes.val);
+                     ctx.import_key_public.publicArea.objectAttributes);
 
     memcpy(ctx.import_key_public.publicArea.unique.sym.buffer,
             ctx.import_key_public_unique_data, TPM2_SHA256_DIGEST_SIZE);

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -111,7 +111,7 @@ int readPublic(TSS2_SYS_CONTEXT *sapi_context, TPMI_DH_OBJECT objectHandle) {
     if (!attrs) {
         LOG_WARN("Could not convert objectAttributes, converting to hex output");
         char tmp[11]; /* UINT32 in hex (8) + "0x" + '\0' */
-        snprintf(tmp, sizeof(tmp), "0x%x", outPublic.publicArea.objectAttributes.val);
+        snprintf(tmp, sizeof(tmp), "0x%x", outPublic.publicArea.objectAttributes);
         attrbuf = tmp;
     }
 

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -72,7 +72,7 @@ static tpm_load_ctx ctx = {
         .sessionHandle = TPM2_RS_PW,
         .nonce = TPM2B_EMPTY_INIT,
         .hmac = TPM2B_EMPTY_INIT,
-        .sessionAttributes = SESSION_ATTRIBUTES_INIT(0)
+        .sessionAttributes = 0
     }
 };
 

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -58,7 +58,7 @@ struct tpm_nvdefine_ctx {
 
 static tpm_nvdefine_ctx ctx = {
     .authHandle = TPM2_RH_PLATFORM,
-    .nvAttribute = SESSION_ATTRIBUTES_INIT(0),
+    .nvAttribute = 0,
     .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW),
     .nvAuth = TPM2B_EMPTY_INIT,
     .size = TPM2_MAX_NV_BUFFER_SIZE,
@@ -92,7 +92,7 @@ static int nv_space_define(TSS2_SYS_CONTEXT *sapi_context) {
     public_info.nvPublic.nameAlg = TPM2_ALG_SHA256;
 
     // Now set the attributes.
-    public_info.nvPublic.attributes.val = ctx.nvAttribute.val;
+    public_info.nvPublic.attributes = ctx.nvAttribute;
 
     if (!ctx.size) {
         LOG_WARN("Defining an index with size 0");
@@ -167,7 +167,7 @@ static bool on_option(char key, char *value) {
         }
         break;
     case 't':
-        result = tpm2_util_string_to_uint32(value, &ctx.nvAttribute.val);
+        result = tpm2_util_string_to_uint32(value, &ctx.nvAttribute);
         if (!result) {
             result = tpm2_attr_util_nv_strtoattr(value, &ctx.nvAttribute);
             if (!result) {

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -63,7 +63,7 @@ static void print_nv_public(TPM2B_NV_PUBLIC *nv_public) {
     tpm2_tool_output("  attributes:\n");
     tpm2_tool_output("    friendly: %s\n", attrs);
     tpm2_tool_output("    value: 0x%X\n",
-            tpm2_util_ntoh_32(nv_public->nvPublic.attributes.val));
+            tpm2_util_ntoh_32(nv_public->nvPublic.attributes));
 
     tpm2_tool_output("  size: %d\n",
                nv_public->nvPublic.dataSize);

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -274,7 +274,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
             return 1;
         }
         ctx.session_data.sessionHandle = ctx.policy_session->sessionHandle;
-        ctx.session_data.sessionAttributes.continueSession = 1;
+        ctx.session_data.sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
     }
 
 

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -268,7 +268,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
             return 1;
         }
         ctx.session_data.sessionHandle = ctx.policy_session->sessionHandle;
-        ctx.session_data.sessionAttributes.continueSession = 1;
+        ctx.session_data.sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
     }
 
     /* Suppress error reporting with NULL path */

--- a/tools/tpm2_takeownership.c
+++ b/tools/tpm2_takeownership.c
@@ -69,7 +69,7 @@ static bool clear_hierarchy_auth(TSS2_SYS_CONTEXT *sapi_context) {
         .sessionHandle = TPM2_RS_PW,
         .nonce = TPM2B_EMPTY_INIT,
         .hmac = TPM2B_EMPTY_INIT,
-        .sessionAttributes = SESSION_ATTRIBUTES_INIT(0),
+        .sessionAttributes = 0,
     };
     TSS2_SYS_CMD_AUTHS sessionsData;
     TPMS_AUTH_COMMAND *sessionDataArray[1];
@@ -98,7 +98,7 @@ static bool change_auth(TSS2_SYS_CONTEXT *sapi_context,
         .sessionHandle = TPM2_RS_PW,
         .nonce = TPM2B_EMPTY_INIT,
         .hmac = TPM2B_EMPTY_INIT,
-        .sessionAttributes = SESSION_ATTRIBUTES_INIT(0),
+        .sessionAttributes = 0,
     };
     TSS2_SYS_CMD_AUTHS sessionsData;
     TPMS_AUTH_COMMAND *sessionDataArray[1];

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -130,7 +130,7 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
         }
 
         ctx.sessionData.sessionHandle = ctx.policy_session->sessionHandle;
-        ctx.sessionData.sessionAttributes.continueSession = 1;
+        ctx.sessionData.sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
     }
 
     return true;


### PR DESCRIPTION
tpm2-tss and spec changed the definition of TPMAs from bitfield
structs to a signel value and defines.
This patch adapts this change.

P.S. This will of course not test on travis, since the version of tpm2-tss is too old over there...