### PR TITLE
 Update SetCmdAuths and GetRspAuths to new parameter type

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -386,16 +386,7 @@ nomem:
 static bool get_key_type(TSS2_SYS_CONTEXT *sapi_context, TPMI_DH_OBJECT objectHandle,
         TPMI_ALG_PUBLIC *type) {
 
-    TPMS_AUTH_RESPONSE session_data_out;
-
-    TPMS_AUTH_RESPONSE *session_data_out_array[1] = {
-            &session_data_out
-    };
-
-    TSS2_SYS_RSP_AUTHS sessions_data_out = {
-            1,
-            &session_data_out_array[0]
-    };
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
     TPM2B_PUBLIC out_public = TPM2B_EMPTY_INIT;
 

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -88,14 +88,9 @@
 		.digest = TPM2B_EMPTY_INIT \
     }
 
-#define TSS2_SYS_CMD_AUTHS_INIT(array) { \
-        .cmdAuthsCount = ARRAY_LEN(array), \
-        .cmdAuths = array, \
-    }
-
-#define TSS2_SYS_RSP_AUTHS_INIT(array) { \
-        .rspAuthsCount = ARRAY_LEN(array), \
-        .rspAuths = array, \
+#define TSS2L_SYS_AUTH_COMMAND_INIT(cnt, array) { \
+        .count = cnt, \
+        .auths = array, \
     }
 
 /*

--- a/lib/tpm_hash.c
+++ b/lib/tpm_hash.c
@@ -67,9 +67,7 @@ TSS2_RC tpm_hash_sequence(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH hash_alg
         return rval;
     }
 
-    TPMS_AUTH_COMMAND cmd_auth = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW);
-    TPMS_AUTH_COMMAND *cmd_session_array[1] = { &cmd_auth };
-    TSS2_SYS_CMD_AUTHS cmd_auth_array = { 1, &cmd_session_array[0] };
+    TSS2L_SYS_AUTH_COMMAND cmd_auth_array = { 1, {{.sessionHandle=TPM2_RS_PW}}};
     unsigned i;
     for (i = 0; i < num_buffers; i++) {
         rval = Tss2_Sys_SequenceUpdate(sapi_context, sequence_handle,
@@ -93,12 +91,9 @@ TSS2_RC tpm_hash_file(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH halg,
     TPM2B_AUTH nullAuth = TPM2B_EMPTY_INIT;
     TPMI_DH_OBJECT sequenceHandle;
 
-    TPMS_AUTH_COMMAND cmdAuth = { .sessionHandle = TPM2_RS_PW, .nonce =
-            TPM2B_EMPTY_INIT, .hmac = TPM2B_EMPTY_INIT, .sessionAttributes =
-            0, };
-    TPMS_AUTH_COMMAND *cmdSessionArray[1] = { &cmdAuth };
-    TSS2_SYS_CMD_AUTHS cmdAuthArray = { 1, &cmdSessionArray[0] };
-
+    TSS2L_SYS_AUTH_COMMAND cmdAuthArray = { 1, {{.sessionHandle = TPM2_RS_PW, 
+            .nonce = TPM2B_EMPTY_INIT, .hmac = TPM2B_EMPTY_INIT,
+            .sessionAttributes = 0, }}};
     unsigned long file_size = 0;
 
     /* Suppress error reporting with NULL path */

--- a/lib/tpm_hmac.c
+++ b/lib/tpm_hmac.c
@@ -71,23 +71,15 @@ TSS2_RC tpm_hmac(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH hashAlg, TPM2B *k
     TPM2B emptyBuffer;
     TPMT_TK_HASHCHECK validation;
 
-    TPMS_AUTH_COMMAND sessionData = {
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1,
+        .auths = {{
             .sessionHandle = TPM2_RS_PW,
             .nonce = {
                     .size = 0,
             },
             .sessionAttributes = 0,
-
-
-    };
-
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-
-    TSS2_SYS_CMD_AUTHS sessionsData;
-
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    }}};
 
     UINT32 rval;
     TPM2_HANDLE keyHandle;
@@ -104,9 +96,6 @@ TSS2_RC tpm_hmac(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH hashAlg, TPM2B *k
             }
     };
 
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
     // Set result size to 0, in case any errors occur
     result->size = 0;
 
@@ -117,13 +106,10 @@ TSS2_RC tpm_hmac(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH hashAlg, TPM2B *k
     }
 
     // Init input sessions struct
-    tpm2_util_copy_tpm2b((TPM2B *)&sessionData.hmac, &keyAuth);
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths = &sessionDataArray[0];
+    sessionsData.count = 1;
+    tpm2_util_copy_tpm2b((TPM2B *)&sessionsData.auths[0].hmac, &keyAuth);
 
     // Init sessions out struct
-    sessionsDataOut.rspAuthsCount = 1;
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
 
     emptyBuffer.size = 0;
 

--- a/test/unit/test_tpm2_errata.c
+++ b/test/unit/test_tpm2_errata.c
@@ -49,9 +49,9 @@ static inline void setcaps(UINT32 level, UINT32 rev, UINT32 day, UINT32 year, TS
 }
 
 TSS2_RC __wrap_Tss2_Sys_GetCapability(TSS2_SYS_CONTEXT *sysContext,
-        TSS2_SYS_CMD_AUTHS const *cmdAuthsArray, TPM2_CAP capability,
+        TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray, TPM2_CAP capability,
         UINT32 property, UINT32 propertyCount, TPMI_YES_NO *moreData,
-        TPMS_CAPABILITY_DATA *capabilityData, TSS2_SYS_RSP_AUTHS *rspAuthsArray) {
+        TPMS_CAPABILITY_DATA *capabilityData, TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray) {
 
     UNUSED(sysContext);
     UNUSED(cmdAuthsArray);

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -86,16 +86,7 @@ static tpm_certify_ctx ctx = {
 };
 
 static bool get_key_type(TSS2_SYS_CONTEXT *sapi_context, TPMI_DH_OBJECT object_handle, TPMI_ALG_PUBLIC *type) {
-
-    TPMS_AUTH_RESPONSE session_data_out;
-    TPMS_AUTH_RESPONSE *session_data_out_array[] = {
-        &session_data_out
-    };
-
-    TSS2_SYS_RSP_AUTHS sessions_data_out = {
-            .rspAuthsCount = ARRAY_LEN(session_data_out_array),
-            .rspAuths = session_data_out_array
-    };
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
     TPM2B_PUBLIC out_public = TPM2B_EMPTY_INIT;
 
@@ -148,26 +139,12 @@ static bool set_scheme(TSS2_SYS_CONTEXT *sapi_context, TPMI_DH_OBJECT key_handle
 
 static bool certify_and_save_data(TSS2_SYS_CONTEXT *sapi_context) {
 
-    TPMS_AUTH_COMMAND *cmd_session_array[ARRAY_LEN(ctx.cmd_auth)] = {
-        &ctx.cmd_auth[0],
-        &ctx.cmd_auth[1]
+    TSS2L_SYS_AUTH_COMMAND cmd_auth_array = {
+        .count = ARRAY_LEN(ctx.cmd_auth),
+        .auths = { ctx.cmd_auth[0], ctx.cmd_auth[1]}
     };
 
-    TSS2_SYS_CMD_AUTHS cmd_auth_array = {
-        .cmdAuthsCount = ARRAY_LEN(cmd_session_array),
-        .cmdAuths = cmd_session_array
-    };
-
-    TPMS_AUTH_RESPONSE session_data_out[ARRAY_LEN(ctx.cmd_auth)];
-    TPMS_AUTH_RESPONSE *session_data_array[] = {
-        &session_data_out[0],
-        &session_data_out[1]
-    };
-
-    TSS2_SYS_RSP_AUTHS sessions_data_out = {
-        .rspAuthsCount = ARRAY_LEN(session_data_array),
-        .rspAuths = session_data_array
-    };
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
     TPM2B_DATA qualifying_data = {
         .size = 4,

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -166,11 +166,8 @@ int setup_alg()
 int create(TSS2_SYS_CONTEXT *sapi_context)
 {
     TSS2_RC rval;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
+    TSS2L_SYS_AUTH_COMMAND sessionsData;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
     TPM2B_DATA              outsideInfo = TPM2B_EMPTY_INIT;
     TPML_PCR_SELECTION      creationPCR;
@@ -181,16 +178,8 @@ int create(TSS2_SYS_CONTEXT *sapi_context)
     TPM2B_DIGEST            creationHash = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
     TPMT_TK_CREATION        creationTicket = TPMT_TK_CREATION_EMPTY_INIT;
 
-    sessionDataArray[0] = &ctx.session_data;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0] = &ctx.session_data;
+    sessionsData.count = 1;
+    sessionsData.auths[0] = ctx.session_data;
 
     ctx.in_sensitive.size = ctx.in_sensitive.sensitive.userAuth.size + 2;
 

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -151,11 +151,8 @@ int setup_alg(void) {
 
 int create_primary(TSS2_SYS_CONTEXT *sapi_context) {
     UINT32 rval;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
+    TSS2L_SYS_AUTH_COMMAND sessionsData;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
     TPM2B_DATA              outsideInfo = TPM2B_EMPTY_INIT;
     TPML_PCR_SELECTION      creationPCR;
@@ -165,14 +162,8 @@ int create_primary(TSS2_SYS_CONTEXT *sapi_context) {
     TPM2B_DIGEST            creationHash = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
     TPMT_TK_CREATION        creationTicket = TPMT_TK_CREATION_EMPTY_INIT;
 
-    sessionDataArray[0] = &ctx.session_data;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsDataOut.rspAuthsCount = 1;
+    sessionsData.count = 1;
+    sessionsData.auths[0] = ctx.session_data;
 
     ctx.inSensitive.size = ctx.inSensitive.sensitive.userAuth.size +
         sizeof(ctx.inSensitive.size);

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -60,18 +60,8 @@ static dictionarylockout_ctx ctx = {
 
 bool dictionary_lockout_reset_and_parameter_setup(TSS2_SYS_CONTEXT *sapi_context) {
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    sessionDataArray[0] = &ctx.session_data;
-
-    TSS2_SYS_CMD_AUTHS sessionsData = { .cmdAuths = &sessionDataArray[0],
-            .cmdAuthsCount = 1 };
-
-    //Response Auths
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1], sessionDataOut;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    TSS2_SYS_RSP_AUTHS sessionsDataOut = { .rspAuths = &sessionDataOutArray[0],
-            .rspAuthsCount = 1 };
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { 1, { ctx.session_data }};
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
     /*
      * If setup params and clear lockout are both required, clear lockout should

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -78,20 +78,11 @@ static bool encrypt_decrypt(TSS2_SYS_CONTEXT *sapi_context) {
 
     TPM2B_IV iv_out = TPM2B_TYPE_INIT(TPM2B_IV, buffer);
 
-    TSS2_SYS_CMD_AUTHS sessions_data;
-    TPMS_AUTH_RESPONSE session_data_out;
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
-    TPMS_AUTH_COMMAND *session_data_array[1];
-    TPMS_AUTH_RESPONSE *session_data_out_array[1];
+    TSS2L_SYS_AUTH_COMMAND sessions_data;
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
-    session_data_array[0] = &ctx.session_data;
-    sessions_data.cmdAuths = &session_data_array[0];
-    session_data_out_array[0] = &session_data_out;
-    sessions_data_out.rspAuths = &session_data_out_array[0];
-    sessions_data_out.rspAuthsCount = 1;
-
-    sessions_data.cmdAuthsCount = 1;
-    sessions_data.cmdAuths[0] = &ctx.session_data;
+    sessions_data.count = 1;
+    sessions_data.auths[0] = ctx.session_data;
 
     TPM2B_IV iv_in = {
         .size = TPM2_MAX_SYM_BLOCK_SIZE,

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -71,20 +71,11 @@ static tpm_evictcontrol_ctx ctx = {
 
 static int evict_control(TSS2_SYS_CONTEXT *sapi_context) {
 
-    TPMS_AUTH_RESPONSE session_data_out;
-    TSS2_SYS_CMD_AUTHS sessions_data;
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
-    TPMS_AUTH_COMMAND *session_data_array[1];
-    TPMS_AUTH_RESPONSE *session_ata_out_array[1];
+    TSS2L_SYS_AUTH_COMMAND sessions_data;
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
-    session_data_array[0] = &ctx.session_data;
-    session_ata_out_array[0] = &session_data_out;
-
-    sessions_data_out.rspAuths = &session_ata_out_array[0];
-    sessions_data.cmdAuths = &session_data_array[0];
-
-    sessions_data_out.rspAuthsCount = 1;
-    sessions_data.cmdAuthsCount = 1;
+    sessions_data.count = 1;
+    sessions_data.auths[0] = ctx.session_data;
 
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_EvictControl(sapi_context, ctx.auth, ctx.handle.object,
                                         &sessions_data, ctx.handle.persist,&sessions_data_out));

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -144,11 +144,8 @@ int set_key_algorithm(TPM2B_PUBLIC *inPublic) {
 int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
 {
     UINT32 rval;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
+    TSS2L_SYS_AUTH_COMMAND sessionsData;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
     TPM2B_SENSITIVE_CREATE inSensitive = TPM2B_TYPE_INIT(TPM2B_SENSITIVE_CREATE, sensitive);
     TPM2B_PUBLIC inPublic = TPM2B_TYPE_INIT(TPM2B_PUBLIC, publicArea);
@@ -164,14 +161,8 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
 
     TPM2_HANDLE handle2048ek;
 
-    sessionDataArray[0] = &ctx.endorse_session_data;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
-    sessionsData.cmdAuthsCount = 1;
+    sessionsData.count = 1;
+    sessionsData.auths[0] = ctx.endorse_session_data;
 
     memcpy(&inSensitive.sensitive.userAuth, &ctx.ek_password,
            sizeof(ctx.ek_password));
@@ -202,7 +193,7 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
             return 1;
         }
 
-        sessionDataArray[0] = &ctx.owner_session_data;
+        sessionsData.auths[0] = ctx.owner_session_data;
 
         rval = TSS2_RETRY_EXP(Tss2_Sys_EvictControl(sapi_context, TPM2_RH_OWNER, handle2048ek,
                                      &sessionsData, ctx.persistent_handle, &sessionsDataOut));

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -70,20 +70,11 @@ static tpm_hmac_ctx ctx = {
 
 TSS2_RC tpm_hmac_file(TSS2_SYS_CONTEXT *sapi_context, TPM2B_DIGEST *result) {
 
-    TPMS_AUTH_RESPONSE session_data_out;
-    TSS2_SYS_CMD_AUTHS sessions_data;
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
-    TPMS_AUTH_COMMAND *session_data_array[1];
-    TPMS_AUTH_RESPONSE *session_data_out_array[1];
+    TSS2L_SYS_AUTH_COMMAND sessions_data;
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
-    session_data_array[0] = &ctx.session_data;
-    session_data_out_array[0] = &session_data_out;
-
-    sessions_data_out.rspAuths = &session_data_out_array[0];
-    sessions_data.cmdAuths = &session_data_array[0];
-
-    sessions_data_out.rspAuthsCount = 1;
-    sessions_data.cmdAuthsCount = 1;
+    sessions_data.count = 1;
+    sessions_data.auths[0] = ctx.session_data;
 
     unsigned long file_size = 0;
 

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -451,21 +451,10 @@ static void create_import_key_private_data(void) {
 static bool import_external_key_and_save_public_private_data(TSS2_SYS_CONTEXT *sapi_context) {
 
 
-    TPMS_AUTH_COMMAND npsessionData = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW);
-    TPMS_AUTH_COMMAND *npsessionDataArray[] = {
-        &npsessionData
-    };
+    TSS2L_SYS_AUTH_COMMAND npsessionsData =
+            TSS2L_SYS_AUTH_COMMAND_INIT(1, {TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW)});
 
-    TSS2_SYS_CMD_AUTHS npsessionsData =
-            TSS2_SYS_CMD_AUTHS_INIT(npsessionDataArray);
-
-    TPMS_AUTH_RESPONSE npsessionDataOut;
-    TPMS_AUTH_RESPONSE *npsessionDataOutArray[] = {
-        &npsessionDataOut
-    };
-
-    TSS2_SYS_RSP_AUTHS npsessionsDataOut =
-            TSS2_SYS_RSP_AUTHS_INIT(npsessionDataOutArray);
+    TSS2L_SYS_AUTH_RESPONSE npsessionsDataOut;
 
     TPMT_SYM_DEF_OBJECT symmetricAlg = {
             .algorithm = TPM2_ALG_AES,

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -84,17 +84,11 @@ static bool on_option(char key, char *value) {
 
 int readPublic(TSS2_SYS_CONTEXT *sapi_context, TPMI_DH_OBJECT objectHandle) {
     UINT32 rval;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
     TPM2B_PUBLIC outPublic = TPM2B_EMPTY_INIT;
     TPM2B_NAME name = TPM2B_TYPE_INIT(TPM2B_NAME, name);
     TPM2B_NAME qualifiedName = TPM2B_TYPE_INIT(TPM2B_NAME, name);
-
-    sessionDataOutArray[0] = &sessionDataOut;
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsDataOut.rspAuthsCount = 1;
 
     rval = TSS2_RETRY_EXP(Tss2_Sys_ReadPublic(sapi_context, objectHandle, 0, &outPublic, &name, &qualifiedName, &sessionsDataOut));
     if(rval != TPM2_RC_SUCCESS)

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -78,22 +78,13 @@ static tpm_load_ctx ctx = {
 
 int load (TSS2_SYS_CONTEXT *sapi_context) {
     UINT32 rval;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
+    TSS2L_SYS_AUTH_COMMAND sessionsData;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
     TPM2B_NAME nameExt = TPM2B_TYPE_INIT(TPM2B_NAME, name);
 
-    sessionDataArray[0] = &ctx.session_data;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
-    sessionsData.cmdAuthsCount = 1;
+    sessionsData.count = 1;
+    sessionsData.auths[0] = ctx.session_data;
 
     rval = TSS2_RETRY_EXP(Tss2_Sys_Load(sapi_context,
                          ctx.parent_handle,

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -92,13 +92,9 @@ static bool get_hierarchy_value(const char *argument_opt,
 
 static bool load_external(TSS2_SYS_CONTEXT *sapi_context) {
 
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
     TPM2B_NAME nameExt = TPM2B_TYPE_INIT(TPM2B_NAME, name);
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsDataOut.rspAuthsCount = 1;
 
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_LoadExternal(sapi_context, 0,
             ctx.private_key.size ? &ctx.private_key : NULL, &ctx.public_key,

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -117,19 +117,13 @@ out:
 
 static bool make_credential_and_save(TSS2_SYS_CONTEXT *sapi_context)
 {
-    TPMS_AUTH_RESPONSE session_data_out;
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
-    TPMS_AUTH_RESPONSE *session_data_out_array[1];
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
     TPM2B_NAME name_ext = TPM2B_TYPE_INIT(TPM2B_NAME, name);
 
     TPM2B_ID_OBJECT cred_blob = TPM2B_TYPE_INIT(TPM2B_ID_OBJECT, credential);
 
     TPM2B_ENCRYPTED_SECRET secret = TPM2B_TYPE_INIT(TPM2B_ENCRYPTED_SECRET, secret);
-
-    session_data_out_array[0] = &session_data_out;
-    sessions_data_out.rspAuths = &session_data_out_array[0];
-    sessions_data_out.rspAuthsCount = 1;
 
     UINT32 rval = TSS2_RETRY_EXP(Tss2_Sys_LoadExternal(sapi_context, 0, NULL, &ctx.public,
             TPM2_RH_NULL, &ctx.rsa2048_handle, &name_ext, &sessions_data_out));

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -68,23 +68,8 @@ static int nv_space_define(TSS2_SYS_CONTEXT *sapi_context) {
 
     TPM2B_NV_PUBLIC public_info = TPM2B_EMPTY_INIT;
 
-    TPMS_AUTH_RESPONSE session_data_out;
-    TSS2_SYS_CMD_AUTHS sessions_data;
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
-
-    TPMS_AUTH_COMMAND *session_data_array[1] = {
-        &ctx.session_data
-    };
-
-    TPMS_AUTH_RESPONSE *session_data_out_array[1] = {
-        &session_data_out
-    };
-
-    sessions_data_out.rspAuths = &session_data_out_array[0];
-    sessions_data.cmdAuths = &session_data_array[0];
-
-    sessions_data_out.rspAuthsCount = 1;
-    sessions_data.cmdAuthsCount = 1;
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
+    TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, { ctx.session_data }};
 
     public_info.size = sizeof(TPMI_RH_NV_INDEX) + sizeof(TPMI_ALG_HASH)
             + sizeof(TPMA_NV) + sizeof(UINT16) + sizeof(UINT16);

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -70,18 +70,8 @@ static tpm_nvread_ctx ctx = {
 static bool nv_read(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
 
-    TPMS_AUTH_COMMAND *session_data_array[] = {
-        &ctx.session_data
-    };
-    TSS2_SYS_CMD_AUTHS sessions_data = TSS2_SYS_CMD_AUTHS_INIT(session_data_array);
-
-
-    TPMS_AUTH_RESPONSE session_data_out;
-    TPMS_AUTH_RESPONSE *session_data_out_array[] = {
-        &session_data_out
-    };
-    TSS2_SYS_RSP_AUTHS sessions_data_out = TSS2_SYS_RSP_AUTHS_INIT(session_data_out_array);
-
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
+    TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, { ctx.session_data }};
 
     TPM2B_NV_PUBLIC nv_public = TPM2B_EMPTY_INIT;
     TSS2_RC rval = tpm2_util_nv_read_public(sapi_context, ctx.nv_index, &nv_public);

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -61,21 +61,8 @@ static tpm_nvreadlock_ctx ctx = {
 
 static bool nv_readlock(TSS2_SYS_CONTEXT *sapi_context) {
 
-    TPMS_AUTH_RESPONSE session_data_out;
-    TSS2_SYS_CMD_AUTHS sessions_data;
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
-
-    TPMS_AUTH_COMMAND *session_data_array[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    session_data_array[0] = &ctx.session_data;
-    sessionDataOutArray[0] = &session_data_out;
-
-    sessions_data_out.rspAuths = &sessionDataOutArray[0];
-    sessions_data.cmdAuths = &session_data_array[0];
-
-    sessions_data_out.rspAuthsCount = 1;
-    sessions_data.cmdAuthsCount = 1;
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
+    TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, { ctx.session_data }};
 
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_NV_ReadLock(sapi_context, ctx.auth_handle, ctx.nv_index,
             &sessions_data, &sessions_data_out));

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -55,12 +55,7 @@ static tpm_nvrelease_ctx ctx = {
 
 static bool nv_space_release(TSS2_SYS_CONTEXT *sapi_context) {
 
-    TSS2_SYS_CMD_AUTHS sessions_data;
-    TPMS_AUTH_COMMAND *session_data_array[1];
-
-    session_data_array[0] = &ctx.session_data;
-    sessions_data.cmdAuths = &session_data_array[0];
-    sessions_data.cmdAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, { ctx.session_data }};
 
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_NV_UndefineSpace(sapi_context, ctx.auth_handle,
                                             ctx.nv_index, &sessions_data, 0));

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -74,19 +74,10 @@ static tpm_nvwrite_ctx ctx = {
 
 static bool nv_write(TSS2_SYS_CONTEXT *sapi_context) {
 
-    TPMS_AUTH_RESPONSE session_data_out;
-    TSS2_SYS_CMD_AUTHS sessions_data;
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
     TPM2B_MAX_NV_BUFFER nv_write_data;
 
-    TPMS_AUTH_COMMAND *session_data_array[1] = { &ctx.session_data };
-    TPMS_AUTH_RESPONSE *session_data_out_array[1] = { &session_data_out };
-
-    sessions_data_out.rspAuths = &session_data_out_array[0];
-    sessions_data.cmdAuths = &session_data_array[0];
-
-    sessions_data_out.rspAuthsCount = 1;
-    sessions_data.cmdAuthsCount = 1;
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
+    TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, { ctx.session_data }};
 
     UINT16 data_offset = 0;
 

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -54,23 +54,8 @@ static bool pcr_extend_one(TSS2_SYS_CONTEXT *sapi_context,
      * TODO SUPPORT AUTH VALUES HERE
      * Bug: https://github.com/01org/tpm2-tools/issues/388
      */
-    TPMS_AUTH_COMMAND session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW);
-
-    TPMS_AUTH_RESPONSE session_data_out;
-    TPMS_AUTH_COMMAND *session_data_array[1];
-    TPMS_AUTH_RESPONSE *session_data_out_array[1];
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
-
-    TSS2_SYS_CMD_AUTHS sessions_data;
-
-    session_data_array[0] = &session_data;
-    session_data_out_array[0] = &session_data_out;
-
-    sessions_data_out.rspAuths = &session_data_out_array[0];
-    sessions_data.cmdAuths = &session_data_array[0];
-
-    sessions_data.cmdAuthsCount = 1;
-    sessions_data_out.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
+    TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, {{ .sessionHandle=TPM2_RS_PW }}};
 
     TSS2_RC rc = TSS2_RETRY_EXP(Tss2_Sys_PCR_Extend(sapi_context, pcr_index, &sessions_data,
             digests, &sessions_data_out));

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -94,31 +94,14 @@ static int quote(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE akHandle, TPML_PCR_
 {
     UINT32 rval;
     TPMT_SIG_SCHEME inScheme;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { 1, {{.sessionHandle=TPM2_RS_PW}}};
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
     TPM2B_ATTEST quoted = TPM2B_TYPE_INIT(TPM2B_ATTEST, attestationData);
     TPMT_SIGNATURE signature;
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
-    sessionsData.cmdAuthsCount = 1;
-
-    sessionData.sessionHandle = TPM2_RS_PW;
     if (is_auth_session) {
-        sessionData.sessionHandle = auth_session_handle;
+        sessionsData.auths[0].sessionHandle = auth_session_handle;
     }
-
-    sessionData.nonce.size = 0;
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
 
     if(!G_flag || !get_signature_scheme(sapi_context, akHandle, sig_hash_algorithm, &inScheme)) {
         inScheme.scheme = TPM2_ALG_NULL;

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -63,19 +63,13 @@ static tpm_readpub_ctx ctx = {
 
 static int read_public_and_save(TSS2_SYS_CONTEXT *sapi_context) {
 
-    TPMS_AUTH_RESPONSE session_out_data;
-    TSS2_SYS_RSP_AUTHS sessions_out_data;
-    TPMS_AUTH_RESPONSE *session_out_data_array[1];
+    TSS2L_SYS_AUTH_RESPONSE sessions_out_data;
 
     TPM2B_PUBLIC public = TPM2B_EMPTY_INIT;
 
     TPM2B_NAME name = TPM2B_TYPE_INIT(TPM2B_NAME, name);
 
     TPM2B_NAME qualified_name = TPM2B_TYPE_INIT(TPM2B_NAME, name);
-
-    session_out_data_array[0] = &session_out_data;
-    sessions_out_data.rspAuths = &session_out_data_array[0];
-    sessions_out_data.rspAuthsCount = ARRAY_LEN(session_out_data_array);
 
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_ReadPublic(sapi_context, ctx.objectHandle, 0,
             &public, &name, &qualified_name, &sessions_out_data));

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -69,18 +69,8 @@ static bool rsa_decrypt_and_save(TSS2_SYS_CONTEXT *sapi_context) {
     TPM2B_DATA label;
     TPM2B_PUBLIC_KEY_RSA message = TPM2B_TYPE_INIT(TPM2B_PUBLIC_KEY_RSA, buffer);
 
-    TSS2_SYS_CMD_AUTHS sessions_data;
-    TPMS_AUTH_RESPONSE session_data_out;
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
-    TPMS_AUTH_COMMAND *session_data_array[1];
-    TPMS_AUTH_RESPONSE *session_data_out_array[1];
-
-    session_data_array[0] = &ctx.session_data;
-    sessions_data.cmdAuths = &session_data_array[0];
-    session_data_out_array[0] = &session_data_out;
-    sessions_data_out.rspAuths = &session_data_out_array[0];
-    sessions_data_out.rspAuthsCount = 1;
-    sessions_data.cmdAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, { ctx.session_data }};
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
     inScheme.scheme = TPM2_ALG_RSAES;
     label.size = 0;

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -65,13 +65,7 @@ static bool rsa_encrypt_and_save(TSS2_SYS_CONTEXT *sapi_context) {
     // Outputs
     TPM2B_PUBLIC_KEY_RSA out_data = TPM2B_TYPE_INIT(TPM2B_PUBLIC_KEY_RSA, buffer);
 
-    TPMS_AUTH_RESPONSE out_session_data;
-    TSS2_SYS_RSP_AUTHS out_sessions_data;
-    TPMS_AUTH_RESPONSE *out_session_data_array[1];
-
-    out_session_data_array[0] = &out_session_data;
-    out_sessions_data.rspAuths = &out_session_data_array[0];
-    out_sessions_data.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_RESPONSE out_sessions_data;
 
     scheme.scheme = TPM2_ALG_RSAES;
     label.size = 0;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -85,18 +85,8 @@ static bool sign_and_save(TSS2_SYS_CONTEXT *sapi_context) {
     TPMT_SIG_SCHEME in_scheme;
     TPMT_SIGNATURE signature;
 
-    TSS2_SYS_CMD_AUTHS sessions_data;
-    TPMS_AUTH_RESPONSE session_data_out;
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
-    TPMS_AUTH_COMMAND *session_data_array[1];
-    TPMS_AUTH_RESPONSE *session_data_out_array[1];
-
-    session_data_array[0] = &ctx.sessionData;
-    sessions_data.cmdAuths = &session_data_array[0];
-    session_data_out_array[0] = &session_data_out;
-    sessions_data_out.rspAuths = &session_data_out_array[0];
-    sessions_data_out.rspAuthsCount = 1;
-    sessions_data.cmdAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, { ctx.sessionData }};
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
     int rc = tpm_hash_compute_data(sapi_context, ctx.halg, TPM2_RH_NULL,
             ctx.msg, ctx.length, &digest, NULL);

--- a/tools/tpm2_takeownership.c
+++ b/tools/tpm2_takeownership.c
@@ -65,20 +65,15 @@ static takeownership_ctx ctx;
 
 static bool clear_hierarchy_auth(TSS2_SYS_CONTEXT *sapi_context) {
 
-    TPMS_AUTH_COMMAND sessionData = {
-        .sessionHandle = TPM2_RS_PW,
-        .nonce = TPM2B_EMPTY_INIT,
-        .hmac = TPM2B_EMPTY_INIT,
-        .sessionAttributes = 0,
-    };
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1,
+        .auths = {{
+            .sessionHandle = TPM2_RS_PW,
+            .nonce = TPM2B_EMPTY_INIT,
+            .hmac = TPM2B_EMPTY_INIT,
+           .sessionAttributes = 0,
+    }}};
 
-    sessionDataArray[0] = &sessionData;
-    sessionsData.cmdAuths = &sessionDataArray[0];
-    sessionsData.cmdAuthsCount = 1;
-
-    memcpy(&sessionData.hmac, &ctx.passwords.lockout.old, sizeof(ctx.passwords.lockout.old));
+    memcpy(&sessionsData.auths[0].hmac, &ctx.passwords.lockout.old, sizeof(ctx.passwords.lockout.old));
 
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_Clear(sapi_context, TPM2_RH_LOCKOUT, &sessionsData, 0));
     if (rval != TPM2_RC_SUCCESS) {
@@ -94,21 +89,16 @@ static bool change_auth(TSS2_SYS_CONTEXT *sapi_context,
         TPMI_RH_HIERARCHY_AUTH auth_handle) {
 
     TPM2B_AUTH newAuth;
-    TPMS_AUTH_COMMAND sessionData = {
-        .sessionHandle = TPM2_RS_PW,
-        .nonce = TPM2B_EMPTY_INIT,
-        .hmac = TPM2B_EMPTY_INIT,
-        .sessionAttributes = 0,
-    };
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionsData.cmdAuths = &sessionDataArray[0];
-    sessionsData.cmdAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1,
+        .auths = {{
+            .sessionHandle = TPM2_RS_PW,
+            .nonce = TPM2B_EMPTY_INIT,
+            .hmac = TPM2B_EMPTY_INIT,
+           .sessionAttributes = 0,
+    }}};
 
     memcpy(&newAuth, &pwd->new, sizeof(pwd->new));
-    memcpy(&sessionData.hmac, &pwd->old, sizeof(pwd->old));
+    memcpy(&sessionsData.auths[0].hmac, &pwd->old, sizeof(pwd->old));
 
     UINT32 rval = TSS2_RETRY_EXP(Tss2_Sys_HierarchyChangeAuth(sapi_context,
             auth_handle, &sessionsData, &newAuth, 0));

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -69,22 +69,10 @@ static tpm_unseal_ctx ctx = {
 
 bool unseal_and_save(TSS2_SYS_CONTEXT *sapi_context) {
 
-    TPMS_AUTH_RESPONSE session_data_out;
-    TSS2_SYS_CMD_AUTHS sessions_data;
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
-    TPMS_AUTH_COMMAND *session_data_array[1];
-    TPMS_AUTH_RESPONSE *session_data_out_array[1];
+    TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, { ctx.sessionData }};
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
     TPM2B_SENSITIVE_DATA outData = TPM2B_TYPE_INIT(TPM2B_SENSITIVE_DATA, buffer);
-
-    session_data_array[0] = &ctx.sessionData;
-    session_data_out_array[0] = &session_data_out;
-
-    sessions_data_out.rspAuths = &session_data_out_array[0];
-    sessions_data.cmdAuths = &session_data_array[0];
-
-    sessions_data_out.rspAuthsCount = 1;
-    sessions_data.cmdAuthsCount = 1;
 
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_Unseal(sapi_context, ctx.itemHandle,
             &sessions_data, &outData, &sessions_data_out));

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -79,13 +79,7 @@ static bool verify_signature(TSS2_SYS_CONTEXT *sapi_context) {
     UINT32 rval;
     TPMT_TK_VERIFIED validation;
 
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataOutArray[0] = &sessionDataOut;
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
     UINT16 i;
     for (i = 0; i < ctx.msgHash.size; i++) {


### PR DESCRIPTION
This implements the corresponding part to tpm2-tss's https://github.com/intel/tpm2-tss/pull/634

Note that this is actually just 1 commit, but ontop of PR #644 

P.S. This will not work on travis, since the version of tpm2-tss is too old