### PR TITLE
Add support for Resource Manager level errors to tpm2_rc_decode tool

### DIFF
--- a/lib/rc-decode.c
+++ b/lib/rc-decode.c
@@ -625,11 +625,6 @@ struct tpm2_rc_entry tpm2_tss_layer_entry [] = {
         .name        = "TSS2_TPM_ERROR_LEVEL",
         .description = "Error produced by the TPM",
     },
-    { /* 10 << 16 = 0xA0000 */
-        .id          = TSS2_TCTI_ERROR_LEVEL,
-        .name        = "TSS2_TCTI_ERROR_LEVEL",
-        .description = "Error from the TCTI"
-    },
     { /* 8 << 16 = 0x80000 */
         .id          = TSS2_SYS_ERROR_LEVEL,
         .name        = "TSS2_SYS_ERROR_LEVEL",
@@ -639,6 +634,11 @@ struct tpm2_rc_entry tpm2_tss_layer_entry [] = {
         .id          = TSS2_SYS_PART2_ERROR_LEVEL,
         .name        = "TSS2_SYS_PART2_RC_LEVEL",
         .description = "Error from the SAPI duplicating TPM error check"
+    },
+    { /* 10 << 16 = 0xA0000 */
+        .id          = TSS2_TCTI_ERROR_LEVEL,
+        .name        = "TSS2_TCTI_ERROR_LEVEL",
+        .description = "Error from the TCTI"
     }
 };
 /* Array of TSS2 error codes from TSS System API section 6.1.2.

--- a/lib/rc-decode.c
+++ b/lib/rc-decode.c
@@ -639,6 +639,16 @@ struct tpm2_rc_entry tpm2_tss_layer_entry [] = {
         .id          = TSS2_TCTI_ERROR_LEVEL,
         .name        = "TSS2_TCTI_ERROR_LEVEL",
         .description = "Error from the TCTI"
+    },
+    { /* 11 << 16 = 0xB0000 */
+        .id          = TSS2_RESMGRTPM_ERROR_LEVEL,
+        .name        = "TSS2_RESMGRTPM_ERROR_LEVEL",
+        .description = "Error from the Resource Manager duplicating TPM error check"
+    },
+    { /* 12 << 16 = 0xC0000 */
+        .id          = TSS2_RESMGR_ERROR_LEVEL,
+        .name        = "TSS2_RESMGR_ERROR_LEVEL",
+        .description = "Error from the Resource Manager"
     }
 };
 /* Array of TSS2 error codes from TSS System API section 6.1.2.

--- a/tools/tpm2_rc_decode.c
+++ b/tools/tpm2_rc_decode.c
@@ -214,9 +214,11 @@ bool print_tpm_rc(TSS2_RC rc) {
     switch (rc_tmp) {
     case TSS2_SYS_ERROR_LEVEL:
     case TSS2_TCTI_ERROR_LEVEL:
+    case TSS2_RESMGR_ERROR_LEVEL:
         ret = print_tpm_rc_tss_error_code(rc);
         break;
     case TSS2_SYS_PART2_ERROR_LEVEL:
+    case TSS2_RESMGRTPM_ERROR_LEVEL:
     case TSS2_TPM_ERROR_LEVEL:
         ret = print_tpm_rc_tpm_error_code(rc);
         break;


### PR DESCRIPTION
This pull request adds support for the tpm2_rc_decode tool to decode response codes sent by the Resource Manager layer.