### PR TITLE
lib: just copy the TPMU_HA union instead of copying its member

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ install:
     - popd && popd
     - git clone https://github.com/01org/TPM2.0-TSS.git
     - pushd TPM2.0-TSS
+    - wget http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2017.09.28.tar.xz
+    - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01
+    - tar xJf autoconf-archive-2017.09.28.tar.xz
+    - cp autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
     - ./bootstrap && ./configure && make -j$(nproc)
     - sudo ../.ci/travis-tss-install.sh
     - popd

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -351,7 +351,7 @@ UINT8* tpm2_extract_plain_signature(UINT16 *size, TPMT_SIGNATURE *signature) {
         if (!buffer) {
             goto nomem;
         }
-        memcpy(buffer, &hmac_sig->na, *size);
+        memcpy(buffer, &hmac_sig, *size);
         break;
     }
     case TPM2_ALG_ECDSA: {


### PR DESCRIPTION
The TPMU_HA is just a union data type, so instead of attempting to copy
.na field, copy the union since both refer to the same memory location.

This also allows the tpm2-tools to be built against the tpm2-tss 1.x
since the TPMU_HA union doesn't have a .na field in that version. So it
prevents the following build error:

lib/tpm2_alg_util.c: In function ‘tpm2_extract_plain_signature’:
lib/tpm2_alg_util.c:348:33: error: ‘TPMU_HA {aka union <anonymous>}’ has no member named ‘na’
         memcpy(buffer, &hmac_sig->na, *size);
                                 ^~
make: *** [Makefile:1871: lib/tpm2_alg_util.o] Error 1

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>