### PR TITLE
lib: mask TPM_RC to only get the bits set by the TPM

### DIFF
--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -36,6 +36,9 @@
 
 #include <sapi/tpm20.h>
 
+#define TPM2_RC_MASK 0xfff
+#define TPM2_RC_GET(code) (code & TPM2_RC_MASK)
+
 #define xstr(s) str(s)
 #define str(s) #s
 
@@ -104,7 +107,7 @@
         TSS2_RC __result = 0;                              \
         do {                                               \
             __result = (expression);                       \
-        } while ((__result & 0x0000ffff) == TPM2_RC_RETRY); \
+        } while (TPM2_RC_GET(__result) == TPM2_RC_RETRY); \
         __result;                                          \
     })
 

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -102,7 +102,7 @@ static bool encrypt_decrypt(TSS2_SYS_CONTEXT *sapi_context) {
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt2(sapi_context, ctx.key_handle,
             &sessions_data, &ctx.data, ctx.is_decrypt, TPM2_ALG_NULL, &iv_in, &out_data,
             &iv_out, &sessions_data_out));
-    if (rval == TPM2_RC_COMMAND_CODE) {
+    if (TPM2_RC_GET(rval) == TPM2_RC_COMMAND_CODE) {
         rval = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt(sapi_context, ctx.key_handle,
                 &sessions_data, ctx.is_decrypt, TPM2_ALG_NULL, &iv_in, &ctx.data,
                 &out_data, &iv_out, &sessions_data_out));


### PR DESCRIPTION
The TPM only uses the lower 12 bits from the 32 bits of TPM_RC, the other
layers uses some of the higher unused 20 bits to indicate from which layer
of the stack the error comes from.

So mask the low-order 12 bits of the TPM_RC variable instead comparing TPM
response codes directly. There's no need to mask when the check is against
TPM_RC_SUCCESS, since in this case the upper 20 bits are going to be zero.

Fixes: #646

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>