### PR TITLE
tpm2_rsaencrypt: fix file argument

### DIFF
--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -127,7 +127,7 @@ static bool on_args(int argc, char **argv) {
         return false;
     }
 
-    ctx.input_path = argv[1];
+    ctx.input_path = argv[0];
 
     return true;
 }


### PR DESCRIPTION
Based on argument ordering and getopt handling, the code was getting lucky and
actually properly grabing the input file at argv[1]. However, the first
item in the array is really argv[0].

A result could be that the input file is NULL, which means read data
from stdin and the tool will hang.

Fixes: #664

Signed-off-by: William Roberts <william.c.roberts@intel.com>