### PR TITLE
tpm2_createpolicy: support to save session context with the option -S

### DIFF
--- a/man/tpm2_createpolicy.1.md
+++ b/man/tpm2_createpolicy.1.md
@@ -46,6 +46,10 @@ These options control creating the policy authorization session:
     Start a policy session of type **TPM_SE_POLICY**. Default without this option
     is **TPM_SE_TRIAL**.
 
+  * **-S**, **--save-session-context**:_CONTEXT\_FILE_:
+    An optional file used to store the session context created by either -e
+    or -a.
+
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)


### PR DESCRIPTION
The new option -S, associated with either -e or -a option, allows to
save the session context to a file.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>