### PR TITLE
tpm2_encryptdecrypt: drop -D YES|NO argument

### DIFF
--- a/test/system/test_tpm2_encryptdecrypt.sh
+++ b/test/system/test_tpm2_encryptdecrypt.sh
@@ -66,9 +66,9 @@ tpm2_create -Q -g sha256 -G symcipher -u key.pub -r key.priv -c primary.ctx
 
 tpm2_load -Q -c primary.ctx -u key.pub -r key.priv -n key.name -C decrypt.ctx
 
-tpm2_encryptdecrypt -Q -c decrypt.ctx -D NO -I secret.dat -o encrypt.out
+tpm2_encryptdecrypt -Q -c decrypt.ctx  -I secret.dat -o encrypt.out
 
-tpm2_encryptdecrypt -Q -c  decrypt.ctx -D YES -I encrypt.out -o decrypt.out
+tpm2_encryptdecrypt -Q -c  decrypt.ctx -D -I encrypt.out -o decrypt.out
 
 exit 0
 

--- a/test/system/test_tpm2_import.sh
+++ b/test/system/test_tpm2_import.sh
@@ -61,7 +61,7 @@ tpm2_load -Q -H 0x81010005 -u import_key.pub -r import_key.priv -n import_key.na
 
 echo "plaintext" > "plain.txt"
 
-tpm2_encryptdecrypt -c import_key.ctx -D NO -I plain.txt -o plain.enc
+tpm2_encryptdecrypt -c import_key.ctx  -I plain.txt -o plain.enc
 
 openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -p sym.key` -iv 0 \
 -aes-128-cfb

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -139,14 +139,7 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         break;
     case 'D':
-        if (!strcasecmp("YES", value)) {
-            ctx.is_decrypt = YES;
-        } else if (!strcasecmp("NO", value)) {
-            ctx.is_decrypt = NO;
-        } else {
-            LOG_ERR("Invalid operation type, got\"%s\"", value);
-            return false;
-        }
+        ctx.is_decrypt = YES;
         break;
     case 'I':
         ctx.data.size = sizeof(ctx.data) - 2;
@@ -190,7 +183,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     const struct option topts[] = {
         {"key-handle",   required_argument, NULL, 'k'},
         {"pwdk",        required_argument, NULL, 'P'},
-        {"decrypt",     required_argument, NULL, 'D'},
+        {"decrypt",      no_argument,       NULL, 'D'},
         {"in-file",      required_argument, NULL, 'I'},
         {"out-file",     required_argument, NULL, 'o'},
         {"key-context",  required_argument, NULL, 'c'},
@@ -200,7 +193,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     ctx.session_data.sessionHandle = TPM2_RS_PW;
 
-    *opts = tpm2_options_new("k:P:D:I:o:c:S:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("k:P:DI:o:c:S:", ARRAY_LEN(topts), topts, on_option, NULL);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
tpm2_encryptdecrypt takes a -D argument to indicate to the
tool to perform a decrypt operation. The option currently
requires an argument of YES or NO. Remove this requirment
and make the default operation encrypt and the -D option
trigger a decryption.

No update to the manpage is required, as this change places it
in line with the man page.

Fixes: #614

Signed-off-by: William Roberts <william.c.roberts@intel.com>