### PR TITLE
configure.ac: enable silent-rules configure option by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -309,8 +309,8 @@ MARKDOWN_COMMON_DEPS = \
 	man/common/tcti.md
 
 man/man1/%.1 : man/%.1.md $(MARKDOWN_COMMON_DEPS)
-	rm -f $@
-	mkdir -p man/man1
+	$(AM_V_GEN)rm -f $@ && \
+	mkdir -p man/man1 && \
 	sed -e '/\[common options\]/r man/common/options.md' \
 	    -e '/\[common options\]/d' \
 	    -e '/\[common tcti options\]/r man/common/tcti.md' \

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,8 @@ AC_PROG_CC
 LT_INIT
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
+# enable "silent-rules" option by default
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_FILES([Makefile])
 AC_CHECK_PROG([PANDOC],[pandoc],[yes])
 AS_IF(


### PR DESCRIPTION
This change is inspired by Andreas Fuchs enabling the silent-rules option
by default on tpm2-tss. The output is much nicer and one can have the old
output anyways by either disabling the silent-rules option or "make V=1".

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>