### PR TITLE
[for 3.0] Makefile.am: Add LICENSE in tarball generated by the make dist target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -260,7 +260,8 @@ test_unit_test_tpm2_errata_SOURCES  = test/unit/test_tpm2_errata.c
 
 endif
 
-EXTRA_DIST = $(top_srcdir)/man
+EXTRA_DIST = $(top_srcdir)/man \
+	     LICENSE
 
 if HAVE_PANDOC
     man1_MANS := \


### PR DESCRIPTION
The LICENSE file that's present in the source code is not distributed in the
tarball generated by the make dist target. Including full license text makes
it easier for people to comply with the desired license terms.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>