### PR TITLE
configure: get version from a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ missing
 Makefile
 Makefile.in
 test-driver
+VERSION

--- a/Makefile.am
+++ b/Makefile.am
@@ -257,7 +257,8 @@ EXTRA_DIST = $(top_srcdir)/man \
 	     LICENSE \
 	     MAINTAINERS.md \
 	     README.md \
-	     RELEASE.md
+	     RELEASE.md \
+	     VERSION
 
 if HAVE_PANDOC
     man1_MANS := \

--- a/bootstrap
+++ b/bootstrap
@@ -2,4 +2,5 @@
 
 AUTORECONF=${AUTORECONF:-autoreconf}
 
+git describe --tags --always --dirty > VERSION
 ${AUTORECONF} --install --sym

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([tpm2-tools],
-    [m4_esyscmd_s([git describe --tags --always --dirty])])
+    [m4_esyscmd_s([cat ./VERSION])])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 LT_INIT


### PR DESCRIPTION
Use the idea in tpm2-abrmd to generate a VERSION file and use this file
to get the software version instead of relying on the fact we're in an
active git tree (this is not the case when we fetch a tarball).

The VERSION file generated by bootstrap is then included in the
distribution.