### PR TITLE
merge 3.X into master

### DIFF
--- a/.ci/travis-tss-install.sh
+++ b/.ci/travis-tss-install.sh
@@ -33,6 +33,6 @@
 # see: https://github.com/travis-ci/travis-ci/issues/3088
 
 PATH=${PATH}:/usr/local/clang/bin
-(pushd ${TRAVIS_BUILD_DIR}/TPM2.0-TSS && \
+(pushd ${TRAVIS_BUILD_DIR}/tpm2-tss && \
  make install && \
  popd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ install:
     - mkdir ibmtpm974 && pushd ibmtpm974 && tar axf ../ibmtpm974.tar.gz && pushd ./src && make
     - ./tpm_server &
     - popd && popd
-    - git clone https://github.com/01org/TPM2.0-TSS.git
-    - pushd TPM2.0-TSS
+    - git clone https://github.com/intel/tpm2-tss.git
+    - pushd tpm2-tss
     - wget http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2017.09.28.tar.xz
     - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01
     - tar xJf autoconf-archive-2017.09.28.tar.xz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
     argument vs using -i.
   * tpm2_dump_capability: outputs human readable command codes.
   * camelCase options are now all lower case. For example, --camelCase becomes --camel-case.
-  * tpm2_import - A new tool for importing external entities, very limited key support.
   * tpm2_quote,readpublic, and sign now have support for pem/der output/inputs. See the
     respective man pages for more details.
   * tpm2_nvread: Has an output file option, -f.


### PR DESCRIPTION
Lots of empty commits, but this forces a sync between the two branches where it matters and gets git describe version on master reporting 3.0 as the nearest tag.