### PR TITLE
[for 3.x] Makefile.am: include integration tests to generated tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -268,7 +268,8 @@ EXTRA_DIST = $(top_srcdir)/man \
 	     LICENSE \
 	     MAINTAINERS.md \
 	     README.md \
-	     RELEASE.md
+	     RELEASE.md \
+	     test/system
 
 if HAVE_PANDOC
     man1_MANS := \


### PR DESCRIPTION
The integration tests are not included in the tarball generated by the
make dist target.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>