### PR TITLE
travis.yml: build and install autoconf-archive from source

### DIFF
--- a/.ci/travis-tss-install.sh
+++ b/.ci/travis-tss-install.sh
@@ -33,6 +33,6 @@
 # see: https://github.com/travis-ci/travis-ci/issues/3088
 
 PATH=${PATH}:/usr/local/clang/bin
-(pushd ${TRAVIS_BUILD_DIR}/TPM2.0-TSS && \
+(pushd ${TRAVIS_BUILD_DIR}/tpm2-tss && \
  make install && \
  popd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,17 +43,18 @@ install:
     - mkdir ibmtpm974 && pushd ibmtpm974 && tar axf ../ibmtpm974.tar.gz && pushd ./src && make
     - ./tpm_server &
     - popd && popd
-    - git clone https://github.com/01org/TPM2.0-TSS.git
-    - pushd TPM2.0-TSS
     - wget http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2017.09.28.tar.xz
     - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01
-    - tar xJf autoconf-archive-2017.09.28.tar.xz
-    - cp autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
+    - tar xJf autoconf-archive-2017.09.28.tar.xz && pushd autoconf-archive-2017.09.28
+    - ./configure --prefix=/usr && make -j$(nproc) && sudo make install
+    - popd
+    - git clone https://github.com/intel/tpm2-tss.git
+    - pushd tpm2-tss
     - ./bootstrap && ./configure && make -j$(nproc)
     - sudo ../.ci/travis-tss-install.sh
     - popd
     - sudo ldconfig /usr/local/lib
-    - git clone https://github.com/01org/tpm2-abrmd.git
+    - git clone https://github.com/intel/tpm2-abrmd.git
     - pushd tpm2-abrmd
     - git am ../.ci/patches/abrmd/* || true
     - ./bootstrap && ./configure --with-dbuspolicydir=/etc/dbus-1/system.d && make -j$(nproc) && sudo make install && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,12 +69,12 @@ install:
     - sudo dpkg -i libcmocka0_1.0.1-2_amd64.deb
     - sudo dpkg -i libcmocka-dev_1.0.1-2_amd64.deb
     # openssl 1.0.2g
-    - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.0.0_1.0.2g-1ubuntu4.9_amd64.deb
-    - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.0.2g-1ubuntu4.9_amd64.deb
-    - sha256sum libssl1.0.0_1.0.2g-1ubuntu4.9_amd64.deb | grep -q 6bb092abbd6f7bfc6d6fff951b7e5d4fc53922d5ae05046a9d070657d4137679
-    - sha256sum libssl-dev_1.0.2g-1ubuntu4.9_amd64.deb | grep -q 3b5b6b97d7ea5b5d5da1696d102986af77c4877dc985ef30c2b5dc117e9d89f6
-    - sudo dpkg -i libssl1.0.0_1.0.2g-1ubuntu4.9_amd64.deb
-    - sudo dpkg -i libssl-dev_1.0.2g-1ubuntu4.9_amd64.deb
+    - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.0.0_1.0.2g-1ubuntu4.10_amd64.deb
+    - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.0.2g-1ubuntu4.10_amd64.deb
+    - sha256sum libssl1.0.0_1.0.2g-1ubuntu4.10_amd64.deb | grep -q 99f550db61b0054715095fc77901280e81235900435f90b7db34af406f053832
+    - sha256sum libssl-dev_1.0.2g-1ubuntu4.10_amd64.deb | grep -q e44b09b81717a9ae86ff17adae1729682cb00b5285710e991f7b61c8a351c744
+    - sudo dpkg -i libssl1.0.0_1.0.2g-1ubuntu4.10_amd64.deb
+    - sudo dpkg -i libssl-dev_1.0.2g-1ubuntu4.10_amd64.deb
 
 script:
     - ./.ci/travis-build-and-run-tests.sh


### PR DESCRIPTION
Commit 590ed9d2ed21 ("travis: fix autconf dependency on tss") fixed the
tpm2-tss dependency with the AX_CODE_COVERAGE macro, by fetching latest
autoconf-archive and copying the macro into the tpm2-tss source code m4
directory.

But now tpm2-abrmd also uses the macro for code coverage and so instead
of duplicating the same logic, install autoconf-archive in the machine.

While being there, clone the tpm2-tss repository from the latest URL.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>