### PR TITLE
tpm2_clear: add tool and rename tpm2_takeownership

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,6 +49,7 @@ LDADD = \
 bin_PROGRAMS = \
     tools/tpm2_activatecredential \
     tools/tpm2_certify \
+    tools/tpm2_clear \
     tools/tpm2_create \
     tools/tpm2_createpolicy \
     tools/tpm2_createprimary \
@@ -147,6 +148,7 @@ lib_libcommon_a_SOURCES = \
 
 TOOL_SRC := tools/tpm2_tool.c tools/tpm2_tool.h
 
+tools_tpm2_clear_SOURCES = tools/tpm2_clear.c $(TOOL_SRC)
 tools_tpm2_create_SOURCES = tools/tpm2_create.c $(TOOL_SRC)
 tools_tpm2_createprimary_SOURCES = tools/tpm2_createprimary.c $(TOOL_SRC)
 tools_tpm2_getcap_SOURCES = tools/tpm2_getcap.c $(TOOL_SRC)
@@ -264,6 +266,7 @@ if HAVE_PANDOC
     man1_MANS := \
     man/man1/tpm2_activatecredential.1 \
     man/man1/tpm2_certify.1 \
+    man/man1/tpm2_clear.1 \
     man/man1/tpm2_create.1 \
     man/man1/tpm2_createpolicy.1 \
     man/man1/tpm2_createprimary.1 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,6 +49,7 @@ LDADD = \
 bin_PROGRAMS = \
     tools/tpm2_activatecredential \
     tools/tpm2_certify \
+    tools/tpm2_changeauth \
     tools/tpm2_clear \
     tools/tpm2_create \
     tools/tpm2_createpolicy \
@@ -86,7 +87,6 @@ bin_PROGRAMS = \
     tools/tpm2_send \
     tools/tpm2_sign \
     tools/tpm2_startup \
-    tools/tpm2_takeownership \
     tools/tpm2_unseal \
     tools/tpm2_verifysignature
 
@@ -162,7 +162,7 @@ tools_tpm2_getmanufec_CFLAG = $(AM_CFLAGS) $(CURL_CFLAGS)
 tools_tpm2_getmanufec_LDADD = $(LDADD) $(CURL_LIBS)
 tools_tpm2_getmanufec_SOURCES = tools/tpm2_getmanufec.c $(TOOL_SRC)
 tools_tpm2_quote_SOURCES = tools/tpm2_quote.c $(TOOL_SRC)
-tools_tpm2_takeownership_SOURCES = tools/tpm2_takeownership.c $(TOOL_SRC)
+tools_tpm2_changeauth_SOURCES = tools/tpm2_changeauth.c $(TOOL_SRC)
 tools_tpm2_getpubek_SOURCES = tools/tpm2_getpubek.c $(TOOL_SRC)
 tools_tpm2_getpubak_SOURCES = tools/tpm2_getpubak.c $(TOOL_SRC)
 tools_tpm2_hash_SOURCES = tools/tpm2_hash.c $(TOOL_SRC)
@@ -266,6 +266,7 @@ if HAVE_PANDOC
     man1_MANS := \
     man/man1/tpm2_activatecredential.1 \
     man/man1/tpm2_certify.1 \
+    man/man1/tpm2_changeauth.1 \
     man/man1/tpm2_clear.1 \
     man/man1/tpm2_create.1 \
     man/man1/tpm2_createpolicy.1 \
@@ -303,7 +304,6 @@ if HAVE_PANDOC
     man/man1/tpm2_send.1 \
     man/man1/tpm2_sign.1 \
     man/man1/tpm2_startup.1 \
-    man/man1/tpm2_takeownership.1 \
     man/man1/tpm2_unseal.1 \
     man/man1/tpm2_verifysignature.1
 endif

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -1,19 +1,19 @@
-% tpm2_takeownership(1) tpm2-tools | General Commands Manual
+% tpm2_changeauth(1) tpm2-tools | General Commands Manual
 %
 % SEPTEMBER 2017
 
 # NAME
 
-**tpm2_takeownership**(1) - Insert authorization values for the owner, endorsement
+**tpm2_changeauth**(1) - Insert authorization values for the owner, endorsement
 and lockout authorizations.
 
 # SYNOPSIS
 
-**tpm2_takeownership** [*OPTIONS*]
+**tpm2_changeauth** [*OPTIONS*]
 
 # DESCRIPTION
 
-**tpm2_takeownership**(1) - performs a hash operation on _FILE_ and returns the results. If
+**tpm2_changeauth**(1) - performs a hash operation on _FILE_ and returns the results. If
 _FILE_ is not specified, then data is read from stdin. If the results of the
 hash will be used in a signing operation that uses a restricted signing key,
 then the ticket returned by this command can indicate that the hash is safe to
@@ -70,13 +70,13 @@ sign.
 Set owner, endorsement and lockout authorizations to an empty auth value:
 
 ```
-tpm2_takeownership -c -L oldlockoutpasswd
+tpm2_changeauth -c -L oldlockoutpasswd
 ```
 
 Set owner, endorsement and lockout authorizations to a new value:
 
 ```
-tpm2_takeownership -o newo -e newe -l newl -O oldo -E olde -L oldl
+tpm2_changeauth -o newo -e newe -l newl -O oldo -E olde -L oldl
 ```
 
 # RETURNS

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -13,11 +13,8 @@ and lockout authorizations.
 
 # DESCRIPTION
 
-**tpm2_changeauth**(1) - performs a hash operation on _FILE_ and returns the results. If
-_FILE_ is not specified, then data is read from stdin. If the results of the
-hash will be used in a signing operation that uses a restricted signing key,
-then the ticket returned by this command can indicate that the hash is safe to
-sign.
+**tpm2_changeauth**(1) - set the various (owner, endorse, locakout)
+authorization values.
 
 # OPTIONS
 
@@ -54,11 +51,6 @@ sign.
     The old lockout authorization value. Passwords should follow the same
     formatting requirements as the -o option.
 
-  * **-c**, **--clear**:
-
-    Clears the 3 authorizations values with  lockout auth, thus one must specify
-    -L.
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)
@@ -66,12 +58,6 @@ sign.
 [password formatting](common/password.md)
 
 # EXAMPLES
-
-Set owner, endorsement and lockout authorizations to an empty auth value:
-
-```
-tpm2_changeauth -c -L oldlockoutpasswd
-```
 
 Set owner, endorsement and lockout authorizations to a new value:
 

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -1,0 +1,64 @@
+tpm2_clear 1 "DECEMBER 2017" tpm2-tools
+==================================================
+
+NAME
+----
+
+tpm2_clear(1) - send a clear command to the TPM.
+
+SYNOPSIS
+--------
+
+`tpm2_clear` [OPTIONS]
+
+DESCRIPTION
+-----------
+
+tpm2_clear(1) - send a clear command to the TPM, i.e. clear the 3 authorization
+values. If the lockout password option is missing, assume NULL.
+
+OPTIONS
+-------
+
+  * **-p**, **--platform**:
+    specifies the tool should operate on the platform hierarchy. By default
+    it operates on the lockout hierarchy.
+
+  * **-L**, **--lockout-password**=_LOCKOUT\_PASSWORD_:
+    The lockout authorization value.
+
+    Passwords should follow the password formatting standards, see section
+    "Password Formatting".
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+[password formatting](common/password.md)
+
+EXAMPLES
+--------
+
+Set owner, endorsement and lockout authorizations to an empty auth value:
+
+```
+tpm2_clear -L oldlockoutpasswd
+```
+
+Clear the authorizations values on the platform hierarchy:
+
+```
+tpm2_clear -p
+```
+
+RETURNS
+-------
+0 on success or 1 on failure.
+
+BUGS
+----
+[Github Issues](https://github.com/01org/tpm2-tools/issues)
+
+HELP
+----
+See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)

--- a/test/system/test_output_formats.sh
+++ b/test/system/test_output_formats.sh
@@ -79,7 +79,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_getpubek -Q -g $alg_ek -f "$file_pubek_orig" -H $handle_ek
 

--- a/test/system/test_output_formats.sh
+++ b/test/system/test_output_formats.sh
@@ -79,7 +79,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_getpubek -Q -g $alg_ek -f "$file_pubek_orig" -H $handle_ek
 

--- a/test/system/test_tpm2_certify.sh
+++ b/test/system/test_tpm2_certify.sh
@@ -45,7 +45,7 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_changeauth -Q -c
+tpm2_clear -Q
 
 tpm2_createprimary -Q -H e -g sha256 -G rsa -C primary.ctx
 

--- a/test/system/test_tpm2_certify.sh
+++ b/test/system/test_tpm2_certify.sh
@@ -45,7 +45,7 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_takeownership -Q -c
+tpm2_changeauth -Q -c
 
 tpm2_createprimary -Q -H e -g sha256 -G rsa -C primary.ctx
 

--- a/test/system/test_tpm2_changeauth.sh
+++ b/test/system/test_tpm2_changeauth.sh
@@ -44,12 +44,12 @@ onerror() {
 }
 trap onerror ERR
 
-tpm2_changeauth -c 
+tpm2_clear
  
 tpm2_changeauth -o $ownerPasswd -e $endorsePasswd -l $lockPasswd
 
 tpm2_changeauth -O $ownerPasswd -E $endorsePasswd -L $lockPasswd -o $new_ownerPasswd -e $new_endorsePasswd -l $new_lockPasswd
 
-tpm2_changeauth -c -L $new_lockPasswd
+tpm2_clear -L $new_lockPasswd
 
 exit 0

--- a/test/system/test_tpm2_changeauth.sh
+++ b/test/system/test_tpm2_changeauth.sh
@@ -44,12 +44,12 @@ onerror() {
 }
 trap onerror ERR
 
-tpm2_takeownership -c 
+tpm2_changeauth -c 
  
-tpm2_takeownership -o $ownerPasswd -e $endorsePasswd -l $lockPasswd
+tpm2_changeauth -o $ownerPasswd -e $endorsePasswd -l $lockPasswd
 
-tpm2_takeownership -O $ownerPasswd -E $endorsePasswd -L $lockPasswd -o $new_ownerPasswd -e $new_endorsePasswd -l $new_lockPasswd
+tpm2_changeauth -O $ownerPasswd -E $endorsePasswd -L $lockPasswd -o $new_ownerPasswd -e $new_endorsePasswd -l $new_lockPasswd
 
-tpm2_takeownership -c -L $new_lockPasswd
+tpm2_changeauth -c -L $new_lockPasswd
 
 exit 0

--- a/test/system/test_tpm2_encryptdecrypt.sh
+++ b/test/system/test_tpm2_encryptdecrypt.sh
@@ -58,7 +58,7 @@ trap onerror ERR
 
 echo "12345678" > secret.dat
 
-tpm2_takeownership -Q -c
+tpm2_changeauth -Q -c
 
 tpm2_createprimary -Q -H e -g sha1 -G rsa -C primary.ctx
 

--- a/test/system/test_tpm2_encryptdecrypt.sh
+++ b/test/system/test_tpm2_encryptdecrypt.sh
@@ -58,7 +58,7 @@ trap onerror ERR
 
 echo "12345678" > secret.dat
 
-tpm2_changeauth -Q -c
+tpm2_clear -Q
 
 tpm2_createprimary -Q -H e -g sha1 -G rsa -C primary.ctx
 

--- a/test/system/test_tpm2_evictcontrol.sh
+++ b/test/system/test_tpm2_evictcontrol.sh
@@ -45,7 +45,7 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_changeauth -Q -c
+tpm2_clear -Q
 
 tpm2_createprimary -Q -H e -g sha256 -G rsa -C primary.ctx
 

--- a/test/system/test_tpm2_evictcontrol.sh
+++ b/test/system/test_tpm2_evictcontrol.sh
@@ -45,7 +45,7 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_takeownership -Q -c
+tpm2_changeauth -Q -c
 
 tpm2_createprimary -Q -H e -g sha256 -G rsa -C primary.ctx
 

--- a/test/system/test_tpm2_flushcontext.sh
+++ b/test/system/test_tpm2_flushcontext.sh
@@ -43,7 +43,7 @@ cleanup() {
 trap cleanup EXIT
 
 cleanup
-tpm2_changeauth -c
+tpm2_clear
 
 # Test for flushing the specified handle
 tpm2_createprimary -Q -H o -g sha256 -G rsa

--- a/test/system/test_tpm2_flushcontext.sh
+++ b/test/system/test_tpm2_flushcontext.sh
@@ -43,7 +43,7 @@ cleanup() {
 trap cleanup EXIT
 
 cleanup
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 # Test for flushing the specified handle
 tpm2_createprimary -Q -H o -g sha256 -G rsa

--- a/test/system/test_tpm2_getmanufec.sh
+++ b/test/system/test_tpm2_getmanufec.sh
@@ -68,8 +68,8 @@ tpm2_getmanufec -g rsa -N -U -O test_ek.pub https://ekop.intel.com/ekcertservice
 cmp ECcert.bin ECcert2.bin
 
 # Test providing endorsement password to create EK and owner password to persist.
-tpm2_takeownership -c
-tpm2_takeownership -o $opass -e $epass
+tpm2_changeauth -c
+tpm2_changeauth -o $opass -e $epass
 
 tpm2_getmanufec -H $handle -U -E ECcert2.bin -f test_ek.pub -o $opass -e $epass \
                 https://ekop.intel.com/ekcertservice/

--- a/test/system/test_tpm2_getmanufec.sh
+++ b/test/system/test_tpm2_getmanufec.sh
@@ -68,7 +68,7 @@ tpm2_getmanufec -g rsa -N -U -O test_ek.pub https://ekop.intel.com/ekcertservice
 cmp ECcert.bin ECcert2.bin
 
 # Test providing endorsement password to create EK and owner password to persist.
-tpm2_changeauth -c
+tpm2_clear
 tpm2_changeauth -o $opass -e $epass
 
 tpm2_getmanufec -H $handle -U -E ECcert2.bin -f test_ek.pub -o $opass -e $epass \

--- a/test/system/test_tpm2_getpubak.sh
+++ b/test/system/test_tpm2_getpubak.sh
@@ -46,7 +46,7 @@ cleanup() {
 	tpm2_evictcontrol -Q -A o -H 0x8101000c 2>/dev/null || true
 
 	# clear tpm state
-	tpm2_changeauth -c
+	tpm2_clear
 }
 trap cleanup EXIT
 

--- a/test/system/test_tpm2_getpubak.sh
+++ b/test/system/test_tpm2_getpubak.sh
@@ -46,7 +46,7 @@ cleanup() {
 	tpm2_evictcontrol -Q -A o -H 0x8101000c 2>/dev/null || true
 
 	# clear tpm state
-	tpm2_takeownership -c
+	tpm2_changeauth -c
 }
 trap cleanup EXIT
 

--- a/test/system/test_tpm2_hmac.sh
+++ b/test/system/test_tpm2_hmac.sh
@@ -70,7 +70,7 @@ cleanup
 
 echo "12345678" > $file_input_data
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 
@@ -100,7 +100,7 @@ cleanup all
 # Test default algorithm selection of sha1
 echo "12345678" > $file_input_data
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_hmac.sh
+++ b/test/system/test_tpm2_hmac.sh
@@ -70,7 +70,7 @@ cleanup
 
 echo "12345678" > $file_input_data
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 
@@ -100,7 +100,7 @@ cleanup all
 # Test default algorithm selection of sha1
 echo "12345678" > $file_input_data
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_listpersistent.sh
+++ b/test/system/test_tpm2_listpersistent.sh
@@ -55,7 +55,7 @@ onerror() {
 }
 trap onerror ERR
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 # Test persisting transient objects
 for idx in "${!keys[@]}"

--- a/test/system/test_tpm2_listpersistent.sh
+++ b/test/system/test_tpm2_listpersistent.sh
@@ -55,7 +55,7 @@ onerror() {
 }
 trap onerror ERR
 
-tpm2_changeauth -c
+tpm2_clear
 
 # Test persisting transient objects
 for idx in "${!keys[@]}"

--- a/test/system/test_tpm2_load.sh
+++ b/test/system/test_tpm2_load.sh
@@ -68,7 +68,7 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_load.sh
+++ b/test/system/test_tpm2_load.sh
@@ -68,7 +68,7 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_loadexternal.sh
+++ b/test/system/test_tpm2_loadexternal.sh
@@ -63,7 +63,7 @@ trap onerror ERR
 
 cleanup
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_loadexternal.sh
+++ b/test/system/test_tpm2_loadexternal.sh
@@ -63,7 +63,7 @@ trap onerror ERR
 
 cleanup
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_nv.sh
+++ b/test/system/test_tpm2_nv.sh
@@ -81,7 +81,7 @@ pyscript
 
 cleanup
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_nvdefine -Q -x $nv_test_index -a $nv_auth_handle -s 32 -t "ownerread|policywrite|ownerwrite"
 

--- a/test/system/test_tpm2_nv.sh
+++ b/test/system/test_tpm2_nv.sh
@@ -81,7 +81,7 @@ pyscript
 
 cleanup
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_nvdefine -Q -x $nv_test_index -a $nv_auth_handle -s 32 -t "ownerread|policywrite|ownerwrite"
 
@@ -206,7 +206,7 @@ fi
 #
 trap onerror ERR
 
-tpm2_takeownership -o owner
+tpm2_changeauth -o owner
 
 tpm2_nvdefine -x 0x1500015 -a 0x40000001 -s 32 \
   -t "policyread|policywrite|authread|authwrite|ownerwrite|ownerread" \

--- a/test/system/test_tpm2_quote.sh
+++ b/test/system/test_tpm2_quote.sh
@@ -78,7 +78,7 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_quote.sh
+++ b/test/system/test_tpm2_quote.sh
@@ -78,7 +78,7 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_readpublic.sh
+++ b/test/system/test_tpm2_readpublic.sh
@@ -60,7 +60,7 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_readpublic.sh
+++ b/test/system/test_tpm2_readpublic.sh
@@ -60,7 +60,7 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_rsadecrypt.sh
+++ b/test/system/test_tpm2_rsadecrypt.sh
@@ -63,7 +63,7 @@ cleanup
 
 echo "12345678" > $file_input_data
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_createprimary -Q -H e -g $alg_hash -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_rsadecrypt.sh
+++ b/test/system/test_tpm2_rsadecrypt.sh
@@ -63,7 +63,7 @@ cleanup
 
 echo "12345678" > $file_input_data
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_createprimary -Q -H e -g $alg_hash -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_rsaencrypt.sh
+++ b/test/system/test_tpm2_rsaencrypt.sh
@@ -60,7 +60,7 @@ cleanup
 
 echo "12345678" > $file_input_data
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_createprimary -Q -H e -g $alg_hash -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_rsaencrypt.sh
+++ b/test/system/test_tpm2_rsaencrypt.sh
@@ -60,7 +60,7 @@ cleanup
 
 echo "12345678" > $file_input_data
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_createprimary -Q -H e -g $alg_hash -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_sign.sh
+++ b/test/system/test_tpm2_sign.sh
@@ -65,7 +65,7 @@ cleanup
 
 echo "12345678" > $file_input_data
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_createprimary -Q -H e -g $alg_hash -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_sign.sh
+++ b/test/system/test_tpm2_sign.sh
@@ -65,7 +65,7 @@ cleanup
 
 echo "12345678" > $file_input_data
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_createprimary -Q -H e -g $alg_hash -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_unseal.sh
+++ b/test/system/test_tpm2_unseal.sh
@@ -68,7 +68,7 @@ cleanup
 
 echo $secret > $file_input_data
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_unseal.sh
+++ b/test/system/test_tpm2_unseal.sh
@@ -68,7 +68,7 @@ cleanup
 
 echo $secret > $file_input_data
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_verifysignature.sh
+++ b/test/system/test_tpm2_verifysignature.sh
@@ -66,7 +66,7 @@ cleanup
 
 echo "12345678" > $file_input_data
 
-tpm2_takeownership -c
+tpm2_changeauth -c
 
 tpm2_createprimary -Q -H e -g $alg_hash -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/test/system/test_tpm2_verifysignature.sh
+++ b/test/system/test_tpm2_verifysignature.sh
@@ -66,7 +66,7 @@ cleanup
 
 echo "12345678" > $file_input_data
 
-tpm2_changeauth -c
+tpm2_clear
 
 tpm2_createprimary -Q -H e -g $alg_hash -G $alg_primary_key -C $file_primary_key_ctx
 

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -47,8 +47,8 @@ struct password {
     TPM2B_AUTH new;
 };
 
-typedef struct takeownership_ctx takeownership_ctx;
-struct takeownership_ctx {
+typedef struct changeauth_ctx changeauth_ctx;
+struct changeauth_ctx {
     struct {
         password owner;
         password endorse;
@@ -61,7 +61,7 @@ struct takeownership_ctx {
     };
 };
 
-static takeownership_ctx ctx;
+static changeauth_ctx ctx;
 
 static bool clear_hierarchy_auth(TSS2_SYS_CONTEXT *sapi_context) {
 

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Intel Corporation nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "log.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+#include "tpm2_password_util.h"
+
+typedef struct clear_ctx clear_ctx;
+struct clear_ctx {
+    bool platform;
+    TPMS_AUTH_COMMAND session_data;
+};
+
+static clear_ctx ctx = {
+    .platform = false,
+    .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW),
+};
+
+static bool clear(TSS2_SYS_CONTEXT *sapi_context) {
+
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { 1, { ctx.session_data }};
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
+    TPMI_RH_CLEAR rh = TPM2_RH_LOCKOUT;
+
+    LOG_INFO ("Sending TPM2_Clear command with %s",
+            ctx.platform ? "TPM2_RH_PLATFORM" : "TPM2_RH_LOCKOUT");
+    if (ctx.platform)
+        rh = TPM2_RH_PLATFORM;
+
+    TSS2_RC rc = TSS2_RETRY_EXP(Tss2_Sys_Clear (sapi_context,
+            rh, &sessionsData, &sessionsDataOut));
+
+    if (rc != TPM2_RC_SUCCESS && rc != TPM2_RC_INITIALIZE) {
+        LOG_ERR ("Tss2_Sys_Clear failed: 0x%x", rc);
+        return false;
+    }
+
+    LOG_INFO ("Success. TSS2_RC: 0x%x", rc);
+    return true;
+}
+
+static bool on_option(char key, char *value) {
+
+    bool result;
+
+    switch (key) {
+    case 'p':
+        ctx.platform = true;
+        break;
+    case 'L':
+        result = tpm2_password_util_from_optarg(value, &ctx.session_data.hmac);
+        if (!result) {
+            LOG_ERR("Invalid lockout password, got\"%s\"", value);
+            return false;
+        }
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
+        { "platform", no_argument, NULL, 'p' },
+        { "lockout-password", required_argument, NULL, 'L' },
+    };
+
+    *opts = tpm2_options_new("pL:", ARRAY_LEN(topts), topts, on_option, NULL);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    return clear(sapi_context) != true;
+}


### PR DESCRIPTION
This PR proposes a few changes (as discussed in PR#696) :

- Add a new tpm2_clear tool whose goal is to provide a way to clear a TPM2 - i.e. remove all (owner + endorse + lockout) authorization values from it.

- Rename tpm2_takeownership to tpm2_changeauth and remove option -c from the newly named tool (since option -c is handled by tpm2_clear). 

Please note that I did not change CHANGELOG.md as it seems this file is a bit outdated (and I frankly don't know where I should explain these changes).