### PR TITLE
test: test_tpm2_nv.sh large_file_name and large_file_read_name should…

### DIFF
--- a/test/system/test_tpm2_nv.sh
+++ b/test/system/test_tpm2_nv.sh
@@ -35,7 +35,7 @@
  nv_auth_handle=0x40000001
 
 large_file_name="nv.test_large_w"
-large_file_read_name="nv.test_large_w"
+large_file_read_name="nv.test_large_r"
 
 alg_pcr_policy=sha1
 pcr_ids="0,1,2,3"


### PR DESCRIPTION
… be different

Currently both are set as nv.test_large_w, so the cmp -s after the redirect tests
will be comparing nv.test_large_w to itself. Change large_file_read_name to
nv.test_large_r.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>