### PR TITLE
nv: don't exceed max nv buffer size for TSS

### DIFF
--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -110,6 +110,10 @@ static bool nv_read(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         return false;
     }
 
+    if (max_data_size > MAX_NV_BUFFER_SIZE) {
+        max_data_size = MAX_NV_BUFFER_SIZE;
+    }
+
     UINT8 *data_buffer = malloc(data_size);
     if (!data_buffer) {
         LOG_ERR("oom");

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -109,6 +109,10 @@ static bool nv_write(TSS2_SYS_CONTEXT *sapi_context) {
         return false;
     }
 
+    if (max_data_size > MAX_NV_BUFFER_SIZE) {
+        max_data_size = MAX_NV_BUFFER_SIZE;
+    }
+
     while (ctx.data_size > 0) {
 
         nv_write_data.size =


### PR DESCRIPTION
Currently if a tpm device supports a max nv buffer size
greater than tss supports we can get buffer overflows. Check
the size returned by the tpm device, and use the min of
that and the max supported by tss.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>