### PR TITLE
Command line option names

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -259,12 +259,12 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv, char **envp,
      * grep -rn case\ \'[a-zA-Z]\' | awk '{print $3}' | sed s/\'//g | sed s/\://g | sort | uniq | less
      */
     struct option long_options [] = {
-        { "tcti",           required_argument, NULL, 'T' },
-        { "help",           no_argument,       NULL, 'h' },
-        { "verbose",        no_argument,       NULL, 'v' },
-        { "quiet",          no_argument,       NULL, 'Q' },
-        { "version",        no_argument,       NULL, 'V' },
-        { "enable-errata", no_argument,        NULL, 'Z' },
+        { "tcti",          required_argument, NULL, 'T' },
+        { "help",          no_argument,       NULL, 'h' },
+        { "verbose",       no_argument,       NULL, 'v' },
+        { "quiet",         no_argument,       NULL, 'Q' },
+        { "version",       no_argument,       NULL, 'V' },
+        { "enable-errata", no_argument,       NULL, 'Z' },
     };
 
     char *tcti_opts = NULL;

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -18,35 +18,35 @@ authorization values.
 
 # OPTIONS
 
-  * **-o**, **--owner-password**=_OWNER\_PASSWORD_:
+  * **-o**, **--owner-passwd**=_OWNER\_PASSWORD_:
     The new owner authorization value.
 
     Passwords should follow the password formatting standards, see section
     "Password Formatting".
 
-  * **-e**, **--endorse-password**=_ENDORSE\_PASSWORD_:
+  * **-e**, **--endorse-passwd**=_ENDORSE\_PASSWORD_:
 
     The new endorse authorization value. Passwords should follow the same
     formatting requirements as the -o option.
 
-  * **-l**, **--lockout-password**=_LOCKOUT\_PASSWORD_:
+  * **-l**, **--lockout-passwd**=_LOCKOUT\_PASSWORD_:
 
     The new lockout authorization value.
 
     The new endorse authorization value. Passwords should follow the same
     formatting requirements as the -o option.
 
-  * **-O**, **--old-ownerPassword**=_OLD\_OWNER\_PASSWORD_:
+  * **-O**, **--old-owner-passwd**=_OLD\_OWNER\_PASSWORD_:
 
     The old owner authorization value. Passwords should follow the same
     formatting requirements as the -o option.
 
-  * **-E**, **--old-endorsePassword**=_OLD\_ENDORSE\_PASSWORD_:
+  * **-E**, **--old-endorse-passwd**=_OLD\_ENDORSE\_PASSWORD_:
 
     The old endorse authorization value. Passwords should follow the same
     formatting requirements as the -o option.
 
-  * **-L**, **--old-lockoutPassword**=_OLD\_LOCKOUT\_PASSWORD_:
+  * **-L**, **--old-lockout-passwd**=_OLD\_LOCKOUT\_PASSWORD_:
 
     The old lockout authorization value. Passwords should follow the same
     formatting requirements as the -o option.

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -24,7 +24,7 @@ OPTIONS
     specifies the tool should operate on the platform hierarchy. By default
     it operates on the lockout hierarchy.
 
-  * **-L**, **--lockout-password**=_LOCKOUT\_PASSWORD_:
+  * **-L**, **--lockout-passwd**=_LOCKOUT\_PASSWORD_:
     The lockout authorization value.
 
     Passwords should follow the password formatting standards, see section

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -35,7 +35,7 @@ server.
   * **-H**, **--handle**=_HANDLE_:
     specifies the handle used to make EK  persistent (hex).
 
-  * **-g**, **--alg**=_ALGORITHM_:
+  * **-g**, **--algorithm**=_ALGORITHM_:
     specifies the algorithm type of EK.
     See section "Supported Public Object Algorithms" for a list of supported
     object algorithms. See section "Algorithm Specifiers" on how to specify

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -41,7 +41,7 @@ server.
     object algorithms. See section "Algorithm Specifiers" on how to specify
     an algorithm argument.
 
-  * **-f**, **--output**=_FILE_:
+  * **-f**, **--out-file**=_FILE_:
     Specifies the file used to save the public portion of EK.
 
   * **-N**, **--non-persistent**:

--- a/man/tpm2_getpubak.1.md
+++ b/man/tpm2_getpubak.1.md
@@ -46,7 +46,7 @@ loaded-key:
   * **-k**, **--ak-handle**=_AK\_HANDLE_:
     Specifies the handle used to make AK persistent.
 
-  * **-g**, **--alg**=_ALGORITHM_:
+  * **-g**, **--algorithm**=_ALGORITHM_:
     Specifies the algorithm type of AK. Algorithms should follow the
     " formatting standards, see section "Algorithm Specifiers".
     See section "Supported Public Object Algorithms" for a list of supported

--- a/man/tpm2_getpubek.1.md
+++ b/man/tpm2_getpubek.1.md
@@ -37,7 +37,7 @@ Refer to:
   * **-H**, **--handle**=_HANDLE_:
     specifies the handle used to make EK  persistent (hex).
 
-  * **-g**, **--alg**=_ALGORITHM_:
+  * **-g**, **--algorithm**=_ALGORITHM_:
     specifies the algorithm type of EK.
     See section "Supported Public Object Algorithms" for a list of supported
     object algorithms. See section "Algorithm Specifiers" on how to specify

--- a/man/tpm2_getrandom.1.md
+++ b/man/tpm2_getrandom.1.md
@@ -17,7 +17,7 @@ generator. The _SIZE_ parameter is expected as the only argument to the tool.
 
 # OPTIONS
 
-  * **-o**, **--output**=_FILE_
+  * **-o**, **--out-file**=_FILE_
     specifies the filename to output the raw bytes to. Defaults to stdout as a hex
     string.
 

--- a/man/tpm2_hash.1.md
+++ b/man/tpm2_hash.1.md
@@ -35,7 +35,7 @@ sign.
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-o**, **--outfile**=_OUT\_FILE_
+  * **-o**, **--out-file**=_OUT\_FILE_
     Optional file record of the hash result. Defaults to stdout in hex form.
 
   * **-t**, **--ticket**=_TICKET\_FILE_

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -34,7 +34,7 @@ _FILE_ is not specified, then data is read from stdin.
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-o**, **--outfile**=_OUT\_FILE_
+  * **-o**, **--out-file**=_OUT\_FILE_
     Optional file record of the HMAC result. Defaults to stdout.
 
   * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -24,7 +24,7 @@
     * **0x40000001** for **TPM_RH_OWNER**
     * **0x4000000C** for **TPM_RH_PLATFORM**
 
-  * **-f**, **--output**=_FILE_:
+  * **-f**, **--out-file**=_FILE_:
     file to write data
 
   * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:

--- a/man/tpm2_pcrevent.1.md
+++ b/man/tpm2_pcrevent.1.md
@@ -38,7 +38,7 @@ These options control extending the pcr:
     specified by _INDEX_.
     It is an error to specify **-S** without specifying a pcr index with **-i**.
 
-  * **-P**, **--password**=_PASSWORD_:
+  * **-P**, **--passwd**=_PASSWORD_:
     Use _PASSWORD_ for providing an authorization value for the pcr specified
     in _INDEX_.
     It is an error to specify **-P** without specifying a pcr index with **-i**.

--- a/man/tpm2_pcrlist.1.md
+++ b/man/tpm2_pcrlist.1.md
@@ -35,7 +35,7 @@ sha256 :
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-o**, **--output**=_FILE_:
+  * **-o**, **--out-file**=_FILE_:
     The output file to write the PCR values in binary format, optional.
 
   * **-L**, **--sel-list**=_PCR\_SELECTION\_LIST_:

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -24,7 +24,7 @@
 
     Filename for the existing AK's context.
 
-  * **-P**, **--ak-password**=_AK\_PASSWORD_:
+  * **-P**, **--ak-passwd**=_AK\_PASSWORD_:
 
     specifies the password of _AK\_HANDLE_. Passwords should follow the
     password formatting standards, see section "Password Formatting".

--- a/man/tpm2_readpublic.1.md
+++ b/man/tpm2_readpublic.1.md
@@ -24,7 +24,7 @@
 
     Filename for object context.
 
-  * **-o**, **--opu**:
+  * **-o**, **--out-file**:
 
     The output file path, recording the public portion of the object.
 

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -42,7 +42,7 @@ data and validation shall indicate that hashed data did not start with
     algorithms.
 
 
-  * **-m**, **--msg**=_MSG\_FILE_:
+  * **-m**, **--message**=_MSG\_FILE_:
 
     The message file, containing the content to be  digested.
 

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -34,7 +34,7 @@ alive and pass that session using the **--input-session-handle** option.
     Specifies the password of _ITEM\_HANDLE_. Passwords should follow the
     password formatting standards, see section "Password Formatting".
 
-  * **-o**, **--outfile**=_OUT\_FILE_:
+  * **-o**, **--out-file**=_OUT\_FILE_:
 
     Output file name, containing the unsealed data. Defaults to stdout if not specified.
 

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -37,7 +37,7 @@ symmetric key, both the public and private portions need to be loaded.
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-m**, **--msg**=_MSG\_FILE_:
+  * **-m**, **--message**=_MSG\_FILE_:
 
     The message file, containing the content to be  digested.
 

--- a/test/system/tests/disabled/import.sh
+++ b/test/system/tests/disabled/import.sh
@@ -51,7 +51,7 @@ tpm2_evictcontrol -Q -A o -c parent.ctx -S 0x81010005
 
 dd if=/dev/urandom of=sym.key bs=1 count=16 2>/dev/null
 
-tpm2_readpublic -Q -H 0x81010005 --opu parent.pub
+tpm2_readpublic -Q -H 0x81010005 --out-file parent.pub
 
 tpm2_import -Q -k sym.key -H 0x81010005 -f parent.pub -q import_key.pub \
 -r import_key.priv

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -274,17 +274,17 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      {"object-handle", required_argument, NULL, 'H'},
-      {"key-handle",    required_argument, NULL, 'k'},
-      {"pwdo",         required_argument, NULL, 'P'},
-      {"pwdk",         required_argument, NULL, 'K'},
-      {"halg",         required_argument, NULL, 'g'},
-      {"attest-file",   required_argument, NULL, 'a'},
-      {"sig-file",      required_argument, NULL, 's'},
-      {"obj-context",   required_argument, NULL, 'C'},
-      {"key-context",   required_argument, NULL, 'c'},
-      { "format",      required_argument, NULL, 'f' },
-      {NULL,           no_argument,       NULL, '\0'}
+      { "object-handle", required_argument, NULL, 'H' },
+      { "key-handle",    required_argument, NULL, 'k' },
+      { "pwdo",          required_argument, NULL, 'P' },
+      { "pwdk",          required_argument, NULL, 'K' },
+      { "halg",          required_argument, NULL, 'g' },
+      { "attest-file",   required_argument, NULL, 'a' },
+      { "sig-file",      required_argument, NULL, 's' },
+      { "obj-context",   required_argument, NULL, 'C' },
+      { "key-context",   required_argument, NULL, 'c' },
+      {  "format",       required_argument, NULL, 'f' },
+      { NULL,            no_argument,       NULL, '\0' }
     };
 
     *opts = tpm2_options_new("H:k:P:K:g:a:s:C:c:f:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -157,10 +157,10 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         { "owner-passwd",     required_argument, NULL, 'o' },
         { "endorse-passwd",   required_argument, NULL, 'e' },
-        { "lock-passwd",      required_argument, NULL, 'l' },
-        { "oldOwnerPasswd",   required_argument, NULL, 'O' },
-        { "oldEndorsePasswd", required_argument, NULL, 'E' },
-        { "oldLockPasswd",    required_argument, NULL, 'L' },
+        { "lockout-passwd",   required_argument, NULL, 'l' },
+        { "old-owner-passwd",   required_argument, NULL, 'O' },
+        { "old-endorse-passwd", required_argument, NULL, 'E' },
+        { "old-ockout-passwd",  required_argument, NULL, 'L' },
     };
 
     *opts = tpm2_options_new("o:e:l:O:E:L:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -155,9 +155,9 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     struct option topts[] = {
-        { "owner-passwd",     required_argument, NULL, 'o' },
-        { "endorse-passwd",   required_argument, NULL, 'e' },
-        { "lockout-passwd",   required_argument, NULL, 'l' },
+        { "owner-passwd",       required_argument, NULL, 'o' },
+        { "endorse-passwd",     required_argument, NULL, 'e' },
+        { "lockout-passwd",     required_argument, NULL, 'l' },
         { "old-owner-passwd",   required_argument, NULL, 'O' },
         { "old-endorse-passwd", required_argument, NULL, 'E' },
         { "old-ockout-passwd",  required_argument, NULL, 'L' },

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -93,7 +93,7 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "platform", no_argument, NULL, 'p' },
+        { "platform",       no_argument,       NULL, 'p' },
         { "lockout-passwd", required_argument, NULL, 'L' },
     };
 

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -94,7 +94,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "platform", no_argument, NULL, 'p' },
-        { "lockout-password", required_argument, NULL, 'L' },
+        { "lockout-passwd", required_argument, NULL, 'L' },
     };
 
     *opts = tpm2_options_new("pL:", ARRAY_LEN(topts), topts, on_option, NULL);

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -317,19 +317,19 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-      {"parent",1,NULL,'H'},
-      {"pwdp",1,NULL,'P'},
-      {"pwdk",1,NULL,'K'},
-      {"halg",1,NULL,'g'},
-      {"kalg",1,NULL,'G'},
-      {"object-attributes",1,NULL,'A'},
-      {"in-file",1,NULL,'I'},
-      {"policy-file",1,NULL,'L'},
-      {"pubfile",1,NULL,'u'},
-      {"privfile",1,NULL,'r'},
-      {"context-parent",1,NULL,'c'},
-      {"input-session-handle",1,NULL,'S'},
-      {0,0,0,0}
+      { "parent",               required_argument, NULL, 'H' },
+      { "pwdp",                 required_argument, NULL, 'P' },
+      { "pwdk",                 required_argument, NULL, 'K' },
+      { "halg",                 required_argument, NULL, 'g' },
+      { "kalg",                 required_argument, NULL, 'G' },
+      { "object-attributes",    required_argument, NULL, 'A' },
+      { "in-file",              required_argument, NULL, 'I' },
+      { "policy-file",          required_argument, NULL, 'L' },
+      { "pubfile",              required_argument, NULL, 'u' },
+      { "privfile",             required_argument, NULL, 'r' },
+      { "context-parent",       required_argument, NULL, 'c' },
+      { "input-session-handle", required_argument, NULL, 'S' },
+      { 0, 0, 0, 0}
     };
 
     setbuf(stdout, NULL);

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -296,16 +296,16 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      {"hierarchy", required_argument, NULL, 'H'},
-      {"pwdp",1,NULL,'P'},
-      {"pwdk",1,NULL,'K'},
-      {"halg",1,NULL,'g'},
-      {"kalg",1,NULL,'G'},
-      {"context",1,NULL,'C'},
-      {"policy-file",1,NULL,'L'},
-      {"object-attributes", required_argument, NULL, 'A'},
-      {"input-session-handle",1,NULL,'S'},
-      {0,0,0,0}
+      { "hierarchy",            required_argument, NULL, 'H' },
+      { "pwdp",                 required_argument, NULL, 'P' },
+      { "pwdk",                 required_argument, NULL, 'K' },
+      { "halg",                 required_argument, NULL, 'g' },
+      { "kalg",                 required_argument, NULL, 'G' },
+      { "context",              required_argument, NULL, 'C' },
+      { "policy-file",          required_argument, NULL, 'L' },
+      { "object-attributes",    required_argument, NULL, 'A' },
+      { "input-session-handle", required_argument, NULL, 'S' },
+      { 0, 0, 0, 0 }
     };
 
     setbuf(stdout, NULL);

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -157,13 +157,13 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "max-tries", required_argument, NULL, 'n' },
-        { "recovery-time", required_argument, NULL, 't' },
+        { "max-tries",             required_argument, NULL, 'n' },
+        { "recovery-time",         required_argument, NULL, 't' },
         { "lockout-recovery-time", required_argument, NULL, 'l' },
-        { "lockout-passwd", required_argument, NULL, 'P' },
-        { "clear-lockout", no_argument, NULL, 'c' },
-        { "setup-parameters", no_argument, NULL, 's' },
-        { "input-session-handle",required_argument,NULL,'S'},
+        { "lockout-passwd",        required_argument, NULL, 'P' },
+        { "clear-lockout",         no_argument,       NULL, 'c' },
+        { "setup-parameters",      no_argument,       NULL, 's' },
+        { "input-session-handle",  required_argument, NULL, 'S' },
     };
 
     *opts = tpm2_options_new("n:t:l:P:S:cs", ARRAY_LEN(topts), topts, on_option, NULL);

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -172,14 +172,14 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        {"key-handle",   required_argument, NULL, 'k'},
-        {"pwdk",        required_argument, NULL, 'P'},
-        {"decrypt",      no_argument,       NULL, 'D'},
-        {"in-file",      required_argument, NULL, 'I'},
-        {"out-file",     required_argument, NULL, 'o'},
-        {"key-context",  required_argument, NULL, 'c'},
-        {"input-session-handle",1,         NULL, 'S'},
-        {NULL,          no_argument,       NULL, '\0'}
+        { "key-handle",           required_argument, NULL, 'k' },
+        { "pwdk",                 required_argument, NULL, 'P' },
+        { "decrypt",              no_argument,       NULL, 'D' },
+        { "in-file",              required_argument, NULL, 'I' },
+        { "out-file",             required_argument, NULL, 'o' },
+        { "key-context",          required_argument, NULL, 'c' },
+        { "input-session-handle", required_argument, NULL, 'S' },
+        { NULL,                   no_argument,       NULL, '\0' }
     };
 
     ctx.session_data.sessionHandle = TPM2_RS_PW;

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -171,13 +171,13 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      {"auth",        required_argument, NULL, 'A'},
-      {"handle",      required_argument, NULL, 'H'},
-      {"persistent",  required_argument, NULL, 'S'},
-      {"pwda",        required_argument, NULL, 'P'},
-      {"context",     required_argument, NULL, 'c'},
-      {"input-session-handle",1,         NULL, 'i'},
-      {NULL,          no_argument,       NULL, '\0'}
+      { "auth",                 required_argument, NULL, 'A' },
+      { "handle",               required_argument, NULL, 'H' },
+      { "persistent",           required_argument, NULL, 'S' },
+      { "pwda",                 required_argument, NULL, 'P' },
+      { "context",              required_argument, NULL, 'c' },
+      { "input-session-handle", required_argument, NULL, 'i' },
+      { NULL,                   no_argument,       NULL, '\0' }
     };
 
     ctx.session_data.sessionHandle = TPM2_RS_PW;

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -525,7 +525,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "handle"       , 1, NULL, 'H' },
         { "ek-passwd"     , 1, NULL, 'P' },
         { "alg"          , 1, NULL, 'g' },
-        { "output"        , 1, NULL, 'f' },
+        { "out-file"      , 1, NULL, 'f' },
         { "non-persistent", 0, NULL, 'N' },
         { "offline"       , 1, NULL, 'O' },
         { "ec-cert"       , 1, NULL, 'E' },

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -520,17 +520,17 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] =
     {
-        { "endorse-passwd", 1, NULL, 'e' },
-        { "owner-passwd"  , 1, NULL, 'o' },
-        { "handle"       , 1, NULL, 'H' },
-        { "ek-passwd"     , 1, NULL, 'P' },
-        { "algorithm"    , 1, NULL, 'g' },
-        { "out-file"      , 1, NULL, 'f' },
-        { "non-persistent", 0, NULL, 'N' },
-        { "offline"       , 1, NULL, 'O' },
-        { "ec-cert"       , 1, NULL, 'E' },
-        { "SSL-NO-VERIFY" , 0, NULL, 'U' },
-        {"input-session-handle",1,NULL,'S'},
+        { "endorse-passwd",       required_argument, NULL, 'e' },
+        { "owner-passwd",         required_argument, NULL, 'o' },
+        { "handle",               required_argument, NULL, 'H' },
+        { "ek-passwd",            required_argument, NULL, 'P' },
+        { "algorithm",            required_argument, NULL, 'g' },
+        { "out-file",             required_argument, NULL, 'f' },
+        { "non-persistent",       no_argument,       NULL, 'N' },
+        { "offline",              required_argument, NULL, 'O' },
+        { "ec-cert",              required_argument, NULL, 'E' },
+        { "SSL-NO-VERIFY",        no_argument,       NULL, 'U' },
+        { "input-session-handle", required_argument, NULL, 'S' },
     };
 
     *opts = tpm2_options_new("e:o:H:P:g:f:NO:E:S:i:U", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -524,7 +524,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "owner-passwd"  , 1, NULL, 'o' },
         { "handle"       , 1, NULL, 'H' },
         { "ek-passwd"     , 1, NULL, 'P' },
-        { "alg"          , 1, NULL, 'g' },
+        { "algorithm"    , 1, NULL, 'g' },
         { "out-file"      , 1, NULL, 'f' },
         { "non-persistent", 0, NULL, 'N' },
         { "offline"       , 1, NULL, 'O' },

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -461,7 +461,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "endorse-passwd", required_argument, NULL, 'e' },
         { "ek-handle"   , required_argument, NULL, 'E' },
         { "ak-handle"   , required_argument, NULL, 'k' },
-        { "alg"        , required_argument, NULL, 'g' },
+        { "algorithm"   , required_argument, NULL, 'g' },
         { "digest-alg"  , required_argument, NULL, 'D' },
         { "sign-alg"    , required_argument, NULL, 's' },
         { "ak-passwd"   , required_argument, NULL, 'P' },

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -457,16 +457,16 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "owner-passwd", required_argument, NULL, 'o' },
+        { "owner-passwd",   required_argument, NULL, 'o' },
         { "endorse-passwd", required_argument, NULL, 'e' },
-        { "ek-handle"   , required_argument, NULL, 'E' },
-        { "ak-handle"   , required_argument, NULL, 'k' },
-        { "algorithm"   , required_argument, NULL, 'g' },
-        { "digest-alg"  , required_argument, NULL, 'D' },
-        { "sign-alg"    , required_argument, NULL, 's' },
-        { "ak-passwd"   , required_argument, NULL, 'P' },
-        { "file"       , required_argument, NULL, 'f' },
-        { "ak-name"     , required_argument, NULL, 'n' },
+        { "ek-handle",      required_argument, NULL, 'E' },
+        { "ak-handle",      required_argument, NULL, 'k' },
+        { "algorithm",      required_argument, NULL, 'g' },
+        { "digest-alg",     required_argument, NULL, 'D' },
+        { "sign-alg",       required_argument, NULL, 's' },
+        { "ak-passwd",      required_argument, NULL, 'P' },
+        { "file",           required_argument, NULL, 'f' },
+        { "ak-name",        required_argument, NULL, 'n' },
     };
 
     *opts = tpm2_options_new("o:E:e:k:g:D:s:P:f:n:p:", ARRAY_LEN(topts), topts, on_option, NULL);

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -295,7 +295,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "owner-passwd"  , required_argument, NULL, 'o' },
         { "handle"       , required_argument, NULL, 'H' },
         { "ek-passwd"     , required_argument, NULL, 'P' },
-        { "alg"          , required_argument, NULL, 'g' },
+        { "algorithm"    , required_argument, NULL, 'g' },
         { "file"         , required_argument, NULL, 'f' },
         {"input-session-handle",1,            NULL, 'S' },
         { "dbg"          , required_argument, NULL, 'd' },

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -291,15 +291,15 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "endorse-passwd", required_argument, NULL, 'e' },
-        { "owner-passwd"  , required_argument, NULL, 'o' },
-        { "handle"       , required_argument, NULL, 'H' },
-        { "ek-passwd"     , required_argument, NULL, 'P' },
-        { "algorithm"    , required_argument, NULL, 'g' },
-        { "file"         , required_argument, NULL, 'f' },
-        {"input-session-handle",1,            NULL, 'S' },
-        { "dbg"          , required_argument, NULL, 'd' },
-        { "help"         , no_argument,       NULL, 'h' },
+        { "endorse-passwd",       required_argument, NULL, 'e' },
+        { "owner-passwd",         required_argument, NULL, 'o' },
+        { "handle",               required_argument, NULL, 'H' },
+        { "ek-passwd",            required_argument, NULL, 'P' },
+        { "algorithm",            required_argument, NULL, 'g' },
+        { "file",                 required_argument, NULL, 'f' },
+        { "input-session-handle", required_argument, NULL, 'S' },
+        { "dbg",                  required_argument, NULL, 'd' },
+        { "help",                 no_argument,       NULL, 'h' },
     };
 
     *opts = tpm2_options_new("e:o:H:P:g:f:p:S:d:hv", ARRAY_LEN(topts), topts, on_option, NULL);

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -106,7 +106,7 @@ static bool on_args(int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "output",   required_argument, NULL, 'o' },
+        { "out-file",   required_argument, NULL, 'o' },
     };
 
     *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts, on_option, on_args);

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -181,10 +181,10 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-        {"hierachy", required_argument, NULL, 'H'},
-        {"halg",     required_argument, NULL, 'g'},
-        {"out-file", required_argument, NULL, 'o'},
-        {"ticket",   required_argument, NULL, 't'},
+        {"hierarchy", required_argument, NULL, 'H'},
+        {"halg",      required_argument, NULL, 'g'},
+        {"out-file",  required_argument, NULL, 'o'},
+        {"ticket",    required_argument, NULL, 't'},
     };
 
     /* set up non-static defaults here */

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -183,7 +183,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     static struct option topts[] = {
         {"hierachy", required_argument, NULL, 'H'},
         {"halg",     required_argument, NULL, 'g'},
-        {"outfile",  required_argument, NULL, 'o'},
+        {"out-file", required_argument, NULL, 'o'},
         {"ticket",   required_argument, NULL, 't'},
     };
 

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -272,13 +272,13 @@ static bool on_args(int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        {"key-handle",   required_argument, NULL, 'k'},
-        {"key-context",  required_argument, NULL, 'c'},
-        {"pwdk",        required_argument, NULL, 'P'},
-        {"algorithm",   required_argument, NULL, 'g'},
-        {"out-file",    required_argument, NULL, 'o'},
-        {"input-session-handle",1,         NULL, 'S'},
-        {NULL,          no_argument,       NULL, '\0'}
+        { "key-handle",           required_argument, NULL, 'k' },
+        { "key-context",          required_argument, NULL, 'c' },
+        { "pwdk",                 required_argument, NULL, 'P' },
+        { "algorithm",            required_argument, NULL, 'g' },
+        { "out-file",             required_argument, NULL, 'o' },
+        { "input-session-handle", required_argument, NULL, 'S' },
+        { NULL,                   no_argument,       NULL, '\0' }
     };
 
     ctx.input = stdin;

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -276,7 +276,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         {"key-context",  required_argument, NULL, 'c'},
         {"pwdk",        required_argument, NULL, 'P'},
         {"algorithm",   required_argument, NULL, 'g'},
-        {"outfile",     required_argument, NULL, 'o'},
+        {"out-file",    required_argument, NULL, 'o'},
         {"input-session-handle",1,         NULL, 'S'},
         {NULL,          no_argument,       NULL, '\0'}
     };

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -176,15 +176,15 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      {"parent",1,NULL,'H'},
-      {"pwdp",1,NULL,'P'},
-      {"pubfile",1,NULL,'u'},
-      {"privfile",1,NULL,'r'},
-      {"name",1,NULL,'n'},
-      {"context",1,NULL,'C'},
-      {"context-parent",1,NULL,'c'},
-      {"input-session-handle",1,NULL,'S'},
-      {0,0,0,0}
+      { "parent",               required_argument, NULL, 'H' },
+      { "pwdp",                 required_argument, NULL, 'P' },
+      { "pubfile",              required_argument, NULL, 'u' },
+      { "privfile",             required_argument, NULL, 'r' },
+      { "name",                 required_argument, NULL, 'n' },
+      { "context",              required_argument, NULL, 'C' },
+      { "context-parent",       required_argument, NULL, 'c' },
+      { "input-session-handle", required_argument, NULL, 'S' },
+      { 0, 0, 0, 0 }
     };
 
     setbuf(stdout, NULL);

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -246,7 +246,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     const struct option topts[] = {
         { "index"       , required_argument, NULL, 'x' },
         { "auth-handle"  , required_argument, NULL, 'a' },
-        { "output"      , required_argument, NULL, 'f' },
+        { "out-file"    , required_argument, NULL, 'f' },
         { "size"        , required_argument, NULL, 's' },
         { "offset"      , required_argument, NULL, 'o' },
         { "handle-passwd", required_argument, NULL, 'P' },

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -244,15 +244,15 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "index"       , required_argument, NULL, 'x' },
-        { "auth-handle"  , required_argument, NULL, 'a' },
-        { "out-file"    , required_argument, NULL, 'f' },
-        { "size"        , required_argument, NULL, 's' },
-        { "offset"      , required_argument, NULL, 'o' },
-        { "handle-passwd", required_argument, NULL, 'P' },
-        { "input-session-handle",1,          NULL, 'S' },
-        {"set-list",       required_argument, NULL, 'L' },
-        {"pcr-input-file", required_argument, NULL, 'F' },
+        { "index",                required_argument, NULL, 'x' },
+        { "auth-handle",          required_argument, NULL, 'a' },
+        { "out-file",             required_argument, NULL, 'f' },
+        { "size",                 required_argument, NULL, 's' },
+        { "offset",               required_argument, NULL, 'o' },
+        { "handle-passwd",        required_argument, NULL, 'P' },
+        { "input-session-handle", required_argument, NULL, 'S' },
+        { "set-list",             required_argument, NULL, 'L' },
+        { "pcr-input-file",       required_argument, NULL, 'F' },
     };
 
     *opts = tpm2_options_new("x:a:f:s:o:P:S:L:F:", ARRAY_LEN(topts),

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -128,11 +128,11 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "index"       , required_argument, NULL, 'x' },
-        { "auth-handle"  , required_argument, NULL, 'a' },
-        { "handle-passwd", required_argument, NULL, 'P' },
-        { "passwdInHex" , no_argument,       NULL, 'X' },
-        { "input-session-handle",1,          NULL, 'S' },
+        { "index",                required_argument, NULL, 'x' },
+        { "auth-handle",          required_argument, NULL, 'a' },
+        { "handle-passwd",        required_argument, NULL, 'P' },
+        { "passwdInHex",          no_argument,       NULL, 'X' },
+        { "input-session-handle", required_argument, NULL, 'S' },
     };
 
     *opts = tpm2_options_new("x:a:P:Xp:d:S:hv", ARRAY_LEN(topts), topts, on_option, NULL);

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -124,10 +124,10 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "index"       , required_argument, NULL, 'x' },
-        { "auth-handle"  , required_argument, NULL, 'a' },
-        { "handle-passwd", required_argument, NULL, 'P' },
-        { "input-session-handle",1,          NULL, 'S' },
+        { "index",                required_argument, NULL, 'x' },
+        { "auth-handle",          required_argument, NULL, 'a' },
+        { "handle-passwd",        required_argument, NULL, 'P' },
+        { "input-session-handle", required_argument, NULL, 'S' },
     };
 
     *opts = tpm2_options_new("x:a:s:o:P:S:", ARRAY_LEN(topts), topts, on_option, NULL);

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -228,13 +228,13 @@ static bool on_args(int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "index"       , required_argument, NULL, 'x' },
-        { "auth-handle"  , required_argument, NULL, 'a' },
-        { "handle-passwd", required_argument, NULL, 'P' },
-        { "input-session-handle",1,          NULL, 'S' },
-        { "offset"      , required_argument, NULL, 'o' },
-        {"set-list",       required_argument, NULL, 'L' },
-        {"pcr-input-file", required_argument, NULL, 'F' },
+        { "index",                required_argument, NULL, 'x' },
+        { "auth-handle",          required_argument, NULL, 'a' },
+        { "handle-passwd",        required_argument, NULL, 'P' },
+        { "input-session-handle", required_argument, NULL, 'S' },
+        { "offset",               required_argument, NULL, 'o' },
+        { "set-list",             required_argument, NULL, 'L' },
+        { "pcr-input-file",       required_argument, NULL, 'F' },
     };
 
     *opts = tpm2_options_new("x:a:P:S:o:L:F:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -333,7 +333,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     static const struct option topts[] = {
         { "pcr-index",            required_argument, NULL, 'i' },
         { "input-session-handle", required_argument, NULL, 'S' },
-        { "passwd",             required_argument, NULL, 'P' },
+        { "passwd",               required_argument, NULL, 'P' },
     };
 
     *opts = tpm2_options_new("i:S:P:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -333,7 +333,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     static const struct option topts[] = {
         { "pcr-index",            required_argument, NULL, 'i' },
         { "input-session-handle", required_argument, NULL, 'S' },
-        { "password",             required_argument, NULL, 'P' },
+        { "passwd",             required_argument, NULL, 'P' },
     };
 
     *opts = tpm2_options_new("i:S:P:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -397,7 +397,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
          { "algorithm", required_argument, NULL, 'g' },
          { "out-file",  required_argument, NULL, 'o' },
          { "algs",      no_argument,       NULL, 's' },
-         { "sel-list",   required_argument, NULL, 'L' },
+         { "sel-list",  required_argument, NULL, 'L' },
          { "format",    required_argument, NULL, 'f' },
      };
 

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -395,7 +395,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
          { "algorithm", required_argument, NULL, 'g' },
-         { "output",    required_argument, NULL, 'o' },
+         { "out-file",  required_argument, NULL, 'o' },
          { "algs",      no_argument,       NULL, 's' },
          { "sel-list",   required_argument, NULL, 'L' },
          { "format",    required_argument, NULL, 'f' },

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -230,7 +230,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     static const struct option topts[] = {
         { "ak-handle",             required_argument, NULL, 'k' },
         { "ak-context",            required_argument, NULL, 'c' },
-        { "ak-password",           required_argument, NULL, 'P' },
+        { "ak-passwd",             required_argument, NULL, 'P' },
         { "id-list",               required_argument, NULL, 'l' },
         { "algorithm",            required_argument, NULL, 'g' },
         { "sel-list",              required_argument, NULL, 'L' },

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -228,13 +228,13 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-        { "ak-handle",             required_argument, NULL, 'k' },
-        { "ak-context",            required_argument, NULL, 'c' },
-        { "ak-passwd",             required_argument, NULL, 'P' },
-        { "id-list",               required_argument, NULL, 'l' },
+        { "ak-handle",            required_argument, NULL, 'k' },
+        { "ak-context",           required_argument, NULL, 'c' },
+        { "ak-passwd",            required_argument, NULL, 'P' },
+        { "id-list",              required_argument, NULL, 'l' },
         { "algorithm",            required_argument, NULL, 'g' },
-        { "sel-list",              required_argument, NULL, 'L' },
-        { "qualify-data",          required_argument, NULL, 'q' },
+        { "sel-list",             required_argument, NULL, 'L' },
+        { "qualify-data",         required_argument, NULL, 'q' },
         { "input-session-handle", required_argument, NULL, 'S' },
         { "signature",            required_argument, NULL, 's' },
         { "message",              required_argument, NULL, 'm' },

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -131,7 +131,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
         { "object",        required_argument, NULL,'H' },
-        { "opu",           required_argument, NULL,'o' },
+        { "out-file",      required_argument, NULL,'o' },
         { "context-object", required_argument, NULL,'c' },
         { "format",        required_argument, NULL,'f' }
     };

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -130,10 +130,10 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-        { "object",        required_argument, NULL,'H' },
-        { "out-file",      required_argument, NULL,'o' },
-        { "context-object", required_argument, NULL,'c' },
-        { "format",        required_argument, NULL,'f' }
+        { "object",         required_argument, NULL, 'H' },
+        { "out-file",       required_argument, NULL, 'o' },
+        { "context-object", required_argument, NULL, 'c' },
+        { "format",         required_argument, NULL, 'f' }
     };
 
     *opts = tpm2_options_new("H:o:c:f:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -148,12 +148,12 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-      { "key-handle",   required_argument, NULL, 'k'},
-      { "pwdk",        required_argument, NULL, 'P'},
-      { "in-file",      required_argument, NULL, 'I'},
-      { "out-file",     required_argument, NULL, 'o'},
-      { "key-context",  required_argument, NULL, 'c'},
-      { "input-session-handle",1,         NULL, 'S' },
+      { "key-handle",           required_argument, NULL, 'k' },
+      { "pwdk",                 required_argument, NULL, 'P' },
+      { "in-file",              required_argument, NULL, 'I' },
+      { "out-file",             required_argument, NULL, 'o' },
+      { "key-context",          required_argument, NULL, 'c' },
+      { "input-session-handle", required_argument, NULL, 'S' },
     };
 
     *opts = tpm2_options_new("k:P:I:o:c:S:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -154,7 +154,7 @@ static bool on_args(int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-        { "--output", required_argument, NULL, 'o' },
+        { "out-file", required_argument, NULL, 'o' },
     };
 
     *opts = tpm2_options_new("i:o:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -157,7 +157,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "out-file", required_argument, NULL, 'o' },
     };
 
-    *opts = tpm2_options_new("i:o:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts,
             on_option, on_args);
 
     ctx.input = stdin;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -253,7 +253,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {"key-handle",            required_argument, NULL, 'k'},
       {"pwdk",                 required_argument, NULL, 'P'},
       {"halg",                 required_argument, NULL, 'g'},
-      {"msg",                  required_argument, NULL, 'm'},
+      {"message",              required_argument, NULL, 'm'},
       {"sig",                  required_argument, NULL, 's'},
       {"ticket",               required_argument, NULL, 't'},
       {"key-context",           required_argument, NULL, 'c'},

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -250,15 +250,15 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-      {"key-handle",            required_argument, NULL, 'k'},
-      {"pwdk",                 required_argument, NULL, 'P'},
-      {"halg",                 required_argument, NULL, 'g'},
-      {"message",              required_argument, NULL, 'm'},
-      {"sig",                  required_argument, NULL, 's'},
-      {"ticket",               required_argument, NULL, 't'},
-      {"key-context",           required_argument, NULL, 'c'},
-      {"input-session-handle", required_argument, NULL, 'S'},
-      {"format",               required_argument, NULL, 'f'}
+      { "key-handle",           required_argument, NULL, 'k' },
+      { "pwdk",                 required_argument, NULL, 'P' },
+      { "halg",                 required_argument, NULL, 'g' },
+      { "message",              required_argument, NULL, 'm' },
+      { "sig",                  required_argument, NULL, 's' },
+      { "ticket",               required_argument, NULL, 't' },
+      { "key-context",          required_argument, NULL, 'c' },
+      { "input-session-handle", required_argument, NULL, 'S' },
+      { "format",               required_argument, NULL, 'f' }
     };
 
     *opts = tpm2_options_new("k:P:g:m:t:s:c:S:f:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -181,14 +181,14 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-      {"item",                 required_argument, NULL, 'H'},
-      {"pwdk",                 required_argument, NULL, 'P'},
-      {"out-file",             required_argument, NULL, 'o'},
-      {"item-context",          required_argument, NULL, 'c'},
-      {"input-session-handle", required_argument, NULL, 'S'},
-      {"set-list",             required_argument, NULL, 'L' },
-      {"pcr-input-file",       required_argument, NULL, 'F' },
-      {NULL,                   no_argument,       NULL, '\0'}
+      { "item",                 required_argument, NULL, 'H' },
+      { "pwdk",                 required_argument, NULL, 'P' },
+      { "out-file",             required_argument, NULL, 'o' },
+      { "item-context",         required_argument, NULL, 'c' },
+      { "input-session-handle", required_argument, NULL, 'S' },
+      { "set-list",             required_argument, NULL, 'L' },
+      { "pcr-input-file",       required_argument, NULL, 'F' },
+      { NULL,                   no_argument,       NULL, '\0' }
     };
 
     *opts = tpm2_options_new("H:P:o:c:S:L:F:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -183,7 +183,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     static const struct option topts[] = {
       {"item",                 required_argument, NULL, 'H'},
       {"pwdk",                 required_argument, NULL, 'P'},
-      {"outfile",              required_argument, NULL, 'o'},
+      {"out-file",             required_argument, NULL, 'o'},
       {"item-context",          required_argument, NULL, 'c'},
       {"input-session-handle", required_argument, NULL, 'S'},
       {"set-list",             required_argument, NULL, 'L' },

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -258,7 +258,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
             { "key-handle",  1, NULL, 'k' },
             { "digest",     1, NULL, 'D' },
             { "halg",       1, NULL, 'g' },
-            { "msg",        1, NULL, 'm' },
+            { "message",    1, NULL, 'm' },
             { "raw",        0, NULL, 'r' },
             { "sig",        1, NULL, 's' },
             { "ticket",     1, NULL, 't' },

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -255,14 +255,14 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-            { "key-handle",  1, NULL, 'k' },
-            { "digest",     1, NULL, 'D' },
-            { "halg",       1, NULL, 'g' },
-            { "message",    1, NULL, 'm' },
-            { "raw",        0, NULL, 'r' },
-            { "sig",        1, NULL, 's' },
-            { "ticket",     1, NULL, 't' },
-            { "key-context", 1, NULL, 'c' },
+            { "key-handle",  required_argument, NULL, 'k' },
+            { "digest",      required_argument, NULL, 'D' },
+            { "halg",        required_argument, NULL, 'g' },
+            { "message",     required_argument, NULL, 'm' },
+            { "raw",         no_argument,       NULL, 'r' },
+            { "sig",         required_argument, NULL, 's' },
+            { "ticket",      required_argument, NULL, 't' },
+            { "key-context", required_argument, NULL, 'c' },
     };
 
 


### PR DESCRIPTION
This series is made of two blocks. 

The first block, containing 5 commits, change some option names to go in the direction of more rationalization. It fixes #729 (or at least it fixes part of this issue). 

The second block of 2 commits begins with a commit that changes all 1 and 0 in the options blocks by the corresponding required_argument or no_argument. The last commit goes one step beyond and re-align all the option definition blocks so that they become easier to read (and maybe easier to parse with various tools). 

Best regards, 

-- Emmanuel Deloget