### PR TITLE
tpm2_print: A tool to print TPM data structures

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,7 @@ LDADD = \
 
 # keep me sorted
 bin_PROGRAMS = \
+    tools/aux/tpm2_print \
     tools/tpm2_activatecredential \
     tools/tpm2_certify \
     tools/tpm2_changeauth \
@@ -154,6 +155,8 @@ lib_libcommon_a_SOURCES = \
     lib/tpm2_session.h
 
 TOOL_SRC := tools/tpm2_tool.c tools/tpm2_tool.h
+
+tools_aux_tpm2_print_SOURCES = tools/aux/tpm2_print.c $(TOOL_SRC)
 
 tools_tpm2_clear_SOURCES = tools/tpm2_clear.c $(TOOL_SRC)
 tools_tpm2_clearlock_SOURCES = tools/tpm2_clearlock.c $(TOOL_SRC)

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -82,7 +82,7 @@
 
 tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
         const struct option *long_opts, tpm2_option_handler on_opt,
-        tpm2_arg_handler on_arg, bool show_usage) {
+        tpm2_arg_handler on_arg, UINT32 flags) {
 
     tpm2_options *opts = calloc(1, sizeof(*opts) + (sizeof(*long_opts) * len));
     if (!opts) {
@@ -108,7 +108,7 @@ tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
     opts->callbacks.on_opt = on_opt;
     opts->callbacks.on_arg = on_arg;
     opts->len = len;
-    opts->show_usage = show_usage;
+    opts->flags = flags;
     memcpy(opts->long_opts, long_opts, len * sizeof(*long_opts));
 
     return opts;
@@ -143,7 +143,7 @@ bool tpm2_options_cat(tpm2_options **dest, tpm2_options *src) {
 
     d->callbacks.on_arg = src->callbacks.on_arg;
     d->callbacks.on_opt = src->callbacks.on_opt;
-    d->show_usage = src->show_usage;
+    d->flags = src->flags;
 
     memcpy(&d->long_opts[d->len], src->long_opts, src->len * sizeof(src->long_opts[0]));
 
@@ -256,7 +256,7 @@ static void show_version (const char *name) {
 void tpm2_print_usage(const char *command, struct tpm2_options *tool_opts) {
     unsigned int i;
 
-    if (!tool_opts || !tool_opts->show_usage) {
+    if (!tool_opts || !(tool_opts->flags & TPM2_OPTIONS_SHOW_USAGE)) {
         return;
     }
 

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -100,8 +100,11 @@ typedef bool (*tpm2_arg_handler)(int argc, char **argv);
  *
  * TPM2_OPTIONS_SHOW_USAGE:
  *  Enable printing a short usage summary (I.e. help)
+ * TPM2_OPTIONS_NO_SAPI:
+ *  Skip SAPI initialization. Removes the "-T" common option.
  */
 #define TPM2_OPTIONS_SHOW_USAGE 0x1
+#define TPM2_OPTIONS_NO_SAPI 0x2
 
 struct tpm2_options {
     struct {

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -95,6 +95,14 @@ typedef bool (*tpm2_option_handler)(char key, char *value);
  */
 typedef bool (*tpm2_arg_handler)(int argc, char **argv);
 
+/**
+ * TPM2_OPTIONS_* flags change default behavior of the argument parser
+ *
+ * TPM2_OPTIONS_SHOW_USAGE:
+ *  Enable printing a short usage summary (I.e. help)
+ */
+#define TPM2_OPTIONS_SHOW_USAGE 0x1
+
 struct tpm2_options {
     struct {
         tpm2_option_handler on_opt;
@@ -102,7 +110,7 @@ struct tpm2_options {
     } callbacks;
     char *short_opts;
     size_t len;
-    bool show_usage;
+    UINT32 flags;
     struct option long_opts[];
 };
 
@@ -123,14 +131,14 @@ typedef struct tpm2_options tpm2_options;
  * @param on_arg
  *  An argument handling callback, which may be null if you don't wish
  *  to handle arguments.
- * @param show_usage
- *  Whether the tool wants a usage short summary text to be printed.
+ * @param flags
+ *  TPM2_OPTIONS_* bit flags
  * @return
  *  NULL on failure or an initialized tpm2_options object.
  */
 tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
         const struct option *long_opts, tpm2_option_handler on_opt,
-        tpm2_arg_handler on_arg, bool show_usage);
+        tpm2_arg_handler on_arg, UINT32 flags);
 
 /**
  * Concatenates two tpm2_options objects, with src appended on

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -346,6 +346,12 @@ static void tpm2_util_public_to_keydata(TPM2B_PUBLIC *public, tpm2_util_keydata 
     return;
 }
 
+void print_yaml_indent(size_t indent_count) {
+    while (indent_count--) {
+        tpm2_tool_output("  ");
+    }
+}
+
 void tpm2_util_public_to_yaml(TPM2B_PUBLIC *public) {
 
     tpm2_tool_output("algorithm:\n");

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -31,9 +31,9 @@
 #include <ctype.h>
 #include <errno.h>
 #include <stdbool.h>
-#include <stdio.h>
 
 #include "log.h"
+#include "files.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_attr_util.h"
 #include "tpm2_tool.h"
@@ -132,7 +132,7 @@ int tpm2_util_hex_to_byte_structure(const char *inStr, UINT16 *byteLength,
     return 0;
 }
 
-void tpm2_util_hexdump(BYTE *data, size_t len, bool plain) {
+void tpm2_util_hexdump(const BYTE *data, size_t len, bool plain) {
 
     if (!output_enabled) {
         return;
@@ -168,6 +168,26 @@ void tpm2_util_hexdump(BYTE *data, size_t len, bool plain) {
         }
         printf("\n");
     }
+}
+
+bool tpm2_util_hexdump_file(FILE *fd, size_t len, bool plain) {
+    BYTE* buff = (BYTE*)malloc(len);
+    if (!buff) {
+        LOG_ERR("malloc() failed");
+        return false;
+    }
+
+    bool res = files_read_bytes(fd, buff, len);
+    if (!res) {
+        LOG_ERR("Failed to read file");
+        free(buff);
+        return false;
+    }
+
+    tpm2_util_hexdump(buff, len, plain);
+
+    free(buff);
+    return true;
 }
 
 /* TODO OPTIMIZE ME */

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -190,6 +190,17 @@ bool tpm2_util_hexdump_file(FILE *fd, size_t len, bool plain) {
     return true;
 }
 
+bool tpm2_util_print_tpm2b_file(FILE *fd)
+{
+    UINT16 len;
+    bool res = files_read_16(fd, &len);
+    if(!res) {
+        LOG_ERR("File read failed");
+        return false;
+    }
+    return tpm2_util_hexdump_file(fd, len, true);
+}
+
 /* TODO OPTIMIZE ME */
 UINT16 tpm2_util_copy_tpm2b(TPM2B *dest, TPM2B *src) {
     int i;

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -33,6 +33,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include <sapi/tpm20.h>
 
@@ -159,7 +160,24 @@ bool tpm2_util_string_to_uint16(const char *str, uint16_t *value);
  *  true for a plain hex string false for an xxd compatable
  *  dump.
  */
-void tpm2_util_hexdump(BYTE *data, size_t len, bool plain);
+void tpm2_util_hexdump(const BYTE *data, size_t len, bool plain);
+
+/**
+ * Prints an xxd compatible hexdump to stdout if output is enabled,
+ * ie no -Q option.
+ *
+ * @param fd
+ *  A readable open file.
+ * @param len
+ *  The length of the data to read and print.
+ * @param plain
+ *  true for a plain hex string false for an xxd compatable
+ *  dump.
+ * @return
+ *  true if len bytes were successfully read and printed,
+ *  false otherwise
+ */
+bool tpm2_util_hexdump_file(FILE *fd, size_t len, bool plain);
 
 /**
  * Prints a TPM2B as a hex dump.

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -281,6 +281,13 @@ UINT64 tpm2_util_ntoh_64(UINT64 data);
 UINT32 tpm2_util_pop_count(UINT32 data);
 
 /**
+ * Prints whitespace indention for yaml output.
+ * @param indent_count
+ *  Number of times to indent
+ */
+void print_yaml_indent(size_t indent_count);
+
+/**
  * Convert a TPM2B_PUBLIC into a yaml format and output if not quiet.
  * @param public
  *  The TPM2B_PUBLIC to output in YAML format.

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -189,6 +189,13 @@ static inline void tpm2_util_print_tpm2b(TPM2B *buffer) {
 }
 
 /**
+ * Reads a TPM2B object from FILE* and prints data in hex.
+ * @param fd
+ *  A readable open file.
+ */
+bool tpm2_util_print_tpm2b_file(FILE *fd);
+
+/**
  * Copies a tpm2b from dest to src and clears dest if src is NULL.
  * If src is NULL, it is a NOP.
  * @param dest

--- a/man/tpm2_print.1.md
+++ b/man/tpm2_print.1.md
@@ -1,0 +1,51 @@
+% tpm2_print(1) tpm2-tools | General Commands Manual
+%
+% DECEMBER 2017
+
+# NAME
+
+**tpm2_print**(1) - Prints TPM data structures
+
+# SYNOPSIS
+
+**tpm2_print** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tpm2_print**(1) decodes a TPM data structure and prints enclosed
+elements to stdout as YAML.
+
+# OPTIONS
+
+  * **-t**, **--type**:
+
+    Required. Type of data structure. Only TPMS_ATTEST is presently
+    supported.
+
+  * **-f**, **--file**:
+
+    Optional. File containing TPM object. Reads from stdin if unspecified.
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+# EXAMPLES
+
+```
+tpm2_print -t TPMS_ATTEST -f /path/to/tpm/quote
+tpm2_print --type=TPMS_ATTEST --file=/path/to/tpm/quote
+cat /path/to/tpm/quote | tpm2_print --type=TPMS_ATTEST
+```
+
+# RETURNS
+
+0 on success. Non-zero otherwise.
+
+# BUGS
+
+[Github Issues](https://github.com/01org/tpm2-tools/issues)
+
+# HELP
+
+See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)

--- a/tools/aux/tpm2_print.c
+++ b/tools/aux/tpm2_print.c
@@ -1,0 +1,318 @@
+//**********************************************************************;
+// Copyright (c) 2017, National Instruments
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <stdio.h>
+
+#include "files.h"
+#include "log.h"
+#include "tpm2_alg_util.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+
+typedef enum {
+    file_type_unknown = 0,
+    file_type_TPMS_ATTEST
+} file_type_id;
+
+typedef struct tpm2_print_ctx tpm2_print_ctx;
+struct tpm2_print_ctx {
+    struct {
+        const char *path;
+        file_type_id type;
+    } file;
+};
+
+static tpm2_print_ctx ctx;
+
+static bool print_clock_info(FILE* fd, size_t indent_count) {
+    union {
+        UINT8  u8;
+        UINT32 u32;
+        UINT64 u64;
+    } numb;
+
+    bool res = files_read_64(fd, &numb.u64);
+    if (!res) {
+        goto read_error;
+    }
+    print_yaml_indent(indent_count);
+    tpm2_tool_output("clock: %llu\n", (long long unsigned int)numb.u64);
+
+    res = files_read_32(fd, &numb.u32);
+    if (!res) {
+        goto read_error;
+    }
+    print_yaml_indent(indent_count);
+    tpm2_tool_output("resetCount: %lu\n", (long unsigned int)numb.u32);
+
+    res = files_read_32(fd, &numb.u32);
+    if (!res) {
+        goto read_error;
+    }
+    print_yaml_indent(indent_count);
+    tpm2_tool_output("restartCount: %lu\n", (long unsigned int)numb.u32);
+
+    res = files_read_bytes(fd, &numb.u8, 1);
+    if (!res) {
+        goto read_error;
+    }
+    print_yaml_indent(indent_count);
+    tpm2_tool_output("safe: %u\n", (unsigned int)numb.u8);
+
+    return true;
+
+read_error:
+    LOG_ERR("File too short");
+    return false;
+}
+
+static bool print_TPMS_QUOTE_INFO(FILE* fd, size_t indent_count) {
+    // read TPML_PCR_SELECTION count (UINT32)
+    UINT32 pcr_selection_count;
+    bool res = files_read_32(fd, &pcr_selection_count);
+    if (!res) {
+        goto read_error;
+    }
+    print_yaml_indent(indent_count);
+    tpm2_tool_output("pcrSelect:\n");
+
+    print_yaml_indent(indent_count + 1);
+    tpm2_tool_output("count: %lu\n", (long unsigned int)pcr_selection_count);
+
+    print_yaml_indent(indent_count + 1);
+    tpm2_tool_output("pcrSelections:\n");
+
+    // read TPML_PCR_SELECTION array (of size count)
+    UINT32 i;
+    for (i = 0; i < pcr_selection_count; ++i) {
+        print_yaml_indent(indent_count + 2);
+        tpm2_tool_output("%lu:\n", (long unsigned int)i);
+
+        // print hash type (TPMI_ALG_HASH)
+        UINT16 hash_type;
+        res = files_read_16(fd, &hash_type);
+        if (!res) {
+            goto read_error;
+        }
+        res = tpm2_alg_util_is_hash_alg(hash_type);
+        if (!res) {
+            LOG_ERR("Invalid hash type in quote");
+            goto error;
+        }
+        const char* const hash_name = tpm2_alg_util_algtostr(hash_type);
+        print_yaml_indent(indent_count + 3);
+        tpm2_tool_output("hash: %u (%s)\n", (unsigned int)hash_type, hash_name);
+
+        UINT8 sizeofSelect;
+        res = files_read_bytes(fd, &sizeofSelect, 1);
+        if (!res) {
+            goto read_error;
+        }
+        print_yaml_indent(indent_count + 3);
+        tpm2_tool_output("sizeofSelect: %u\n", (unsigned int)sizeofSelect);
+
+        // print PCR selection in hex
+        print_yaml_indent(indent_count + 3);
+        tpm2_tool_output("pcrSelect: ");
+        res = tpm2_util_hexdump_file(fd, sizeofSelect, true);
+        tpm2_tool_output("\n");
+        if (!res) {
+            goto read_error;
+        }
+    }
+
+    // print digest in hex (a TPM2B object)
+    print_yaml_indent(indent_count);
+    tpm2_tool_output("pcrDigest: ");
+    res = tpm2_util_print_tpm2b_file(fd);
+    tpm2_tool_output("\n");
+    if (!res) {
+        goto read_error;
+    }
+
+    return true;
+
+read_error:
+    LOG_ERR("File too short");
+error:
+    return false;
+}
+
+static bool print_TPMS_ATTEST_yaml(FILE* fd) {
+    // print magic without converting endianness
+    UINT32 magic;
+    bool res = files_read_bytes(fd, (UINT8*)&magic, sizeof(UINT32));
+    if (!res) {
+        goto read_error;
+    }
+    tpm2_tool_output("magic: ");
+    tpm2_util_hexdump((const UINT8*)&magic, sizeof(UINT32), true);
+    tpm2_tool_output("\n");
+    magic = tpm2_util_ntoh_32(magic); // finally, convert endianness
+
+    // check magic
+    if (magic != TPM2_GENERATED_VALUE) {
+        LOG_ERR("Bad magic");
+        goto error;
+    }
+
+    UINT16 type;
+    res = files_read_bytes(fd, (UINT8*)&type, sizeof(UINT16));
+    if (!res) {
+        goto read_error;
+    }
+    tpm2_tool_output("type: ");
+    tpm2_util_hexdump((const UINT8*)&type, sizeof(UINT16), true);
+    tpm2_tool_output("\n");
+    type = tpm2_util_ntoh_16(type); // finally, convert endianness
+
+    tpm2_tool_output("qualifiedSigner: ");
+    res = tpm2_util_print_tpm2b_file(fd);
+    tpm2_tool_output("\n");
+    if (!res) {
+        goto read_error;
+    }
+
+    tpm2_tool_output("extraData: ");
+    res = tpm2_util_print_tpm2b_file(fd);
+    tpm2_tool_output("\n");
+    if (!res) {
+        goto read_error;
+    }
+
+    tpm2_tool_output("clockInfo:\n");
+    res = print_clock_info(fd, 1);
+    if (!res) {
+        goto error;
+    }
+
+    tpm2_tool_output("firmwareVersion: ");
+    res = tpm2_util_hexdump_file(fd, sizeof(UINT64), true);
+    tpm2_tool_output("\n");
+    if (!res) {
+        goto read_error;
+    }
+
+    switch(type) {
+    case TPM2_ST_ATTEST_QUOTE:
+        tpm2_tool_output("attested:\n");
+        print_yaml_indent(1);
+        tpm2_tool_output("quote:\n");
+        res = print_TPMS_QUOTE_INFO(fd, 2);
+        if (!res) {
+            goto error;
+        }
+        break;
+
+    default:
+        LOG_ERR("Cannot print unsupported type 0x%x", (unsigned int)type);
+        goto error;
+    }
+
+    return true;
+
+read_error:
+    LOG_ERR("File too short");
+error:
+    return false;
+}
+
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 't':
+        if (strcmp(value, "TPMS_ATTEST") != 0) {
+            LOG_ERR("Invalid type specified. Only TPMS_ATTEST is presently supported.");
+            return false;
+        }
+        ctx.file.type = file_type_TPMS_ATTEST;
+        break;
+    case 'f':
+        ctx.file.path = value;
+        break;
+    default:
+        LOG_ERR("Invalid option %c", key);
+        return false;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+    static const struct option topts[] = {
+        { "type",        required_argument, NULL, 't' },
+        { "file",        optional_argument, NULL, 'f' },
+    };
+
+    *opts = tpm2_options_new("t:f:", ARRAY_LEN(topts), topts,
+        on_option, NULL, TPM2_OPTIONS_SHOW_USAGE|TPM2_OPTIONS_NO_SAPI);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+    UNUSED(sapi_context);
+    UNUSED(flags);
+
+    bool (*print_fn)(FILE*) = NULL;
+
+    switch (ctx.file.type) {
+    case file_type_TPMS_ATTEST:
+        print_fn = print_TPMS_ATTEST_yaml;
+        break;
+    default:
+        LOG_ERR("Must specify a file type with -t option");
+        return 1;
+    }
+
+    FILE* fd = stdin;
+
+    if (ctx.file.path) {
+        LOG_INFO("Reading from file %s", ctx.file.path);
+        fd = fopen(ctx.file.path, "rb");
+        if(!fd) {
+            LOG_ERR("Could not open file %s", ctx.file.path);
+            return 1;
+        }
+    }
+    else {
+        LOG_INFO("Reading from stdin");
+    }
+
+    bool res = print_fn(fd);
+
+    LOG_INFO("Read %ld bytes from file %s", ftell(fd), ctx.file.path);
+
+    if (fd != stdin) {
+        fclose(fd);
+    }
+
+    return res ? 0 : 1;
+}

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -291,7 +291,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("H:c:k:C:P:e:f:o:X", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -287,7 +287,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("H:k:P:K:g:a:s:C:c:f:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -164,7 +164,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("o:e:l:O:E:L:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, false);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -98,7 +98,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("pL:", ARRAY_LEN(topts), topts, on_option, NULL,
-                             false);
+                             0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_clearlock.c
+++ b/tools/tpm2_clearlock.c
@@ -107,7 +107,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("cL:p", ARRAY_LEN(topts), topts,
-                             on_option, NULL, false);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -338,7 +338,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
     *opts = tpm2_options_new("H:P:K:g:G:A:I:L:u:r:c:S:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -193,7 +193,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("f:g:L:F:Pa", ARRAY_LEN(topts), topts, on_option,
-                             NULL, true);
+                             NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -314,7 +314,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
     *opts = tpm2_options_new("A:P:K:g:G:C:L:S:H:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -170,7 +170,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("n:t:l:P:S:cs", ARRAY_LEN(topts), topts, on_option,
-                             NULL, true);
+                             NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -186,7 +186,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     ctx.session_data.sessionHandle = TPM2_RS_PW;
 
     *opts = tpm2_options_new("k:P:DI:o:c:S:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, true);
+                             NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -183,7 +183,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     ctx.session_data.sessionHandle = TPM2_RS_PW;
 
     *opts = tpm2_options_new("A:H:p:P:c:S:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, true);
+                             NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -142,7 +142,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("H:tlsS:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -843,7 +843,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("c:", ARRAY_LEN(topts), topts, on_option, NULL,
-                             true);
+                             TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -533,7 +533,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("e:o:H:P:g:f:NO:E:S:i:U", ARRAY_LEN(topts), topts,
-                             on_option, on_args, true);
+                             on_option, on_args, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -483,7 +483,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("o:E:e:k:g:D:s:P:f:n:p:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -305,7 +305,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("e:o:H:P:g:f:p:S:d:hv", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -110,7 +110,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts, on_option, on_args,
-                             true);
+                             TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -191,7 +191,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     ctx.input_file = stdin;
 
     *opts = tpm2_options_new("H:g:o:t:", ARRAY_LEN(topts), topts, on_option,
-                             on_args, false);
+                             on_args, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -286,7 +286,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     ctx.input = stdin;
 
     *opts = tpm2_options_new("k:P:g:o:S:c:", ARRAY_LEN(topts), topts, on_option,
-                             on_args, true);
+                             on_args, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -584,7 +584,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
     *opts = tpm2_options_new("k:H:f:q:r:A:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, true);
+                             NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -137,7 +137,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("g:G:", ARRAY_LEN(topts), topts, on_option, NULL,
-                             false);
+                             0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -193,7 +193,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
     *opts = tpm2_options_new("H:P:u:r:n:C:c:S:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -151,7 +151,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("H:u:r:C:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, true);
+                             NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -196,7 +196,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("e:s:n:o:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, true);
+                             NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -202,7 +202,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("x:a:s:t:P:I:rwdL:S:X", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -260,7 +260,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("x:a:f:s:o:P:S:L:F:", ARRAY_LEN(topts),
-                             topts, on_option, NULL, true);
+                             topts, on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -139,7 +139,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("x:a:P:Xp:d:S:hv", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -134,7 +134,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("x:a:s:o:P:S:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, true);
+                             NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -239,7 +239,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("x:a:P:S:o:L:F:", ARRAY_LEN(topts), topts,
-                             on_option, on_args, false);
+                             on_option, on_args, 0);
 
     ctx.input_file = stdin;
 

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -336,7 +336,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("i:S:P:", ARRAY_LEN(topts), topts,
-                             on_option, on_arg, false);
+                             on_option, on_arg, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -105,7 +105,7 @@ static bool on_arg(int argc, char **argv) {
 
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
-    *opts = tpm2_options_new(NULL, 0, NULL, NULL, on_arg, false);
+    *opts = tpm2_options_new(NULL, 0, NULL, NULL, on_arg, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -402,7 +402,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
      };
 
     *opts = tpm2_options_new("g:o:L:s", ARRAY_LEN(topts), topts,
-                             on_option, NULL, false);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_policypcr.c
+++ b/tools/tpm2_policypcr.c
@@ -90,7 +90,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("f:F:L:S:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, false);
+                             NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_policyrestart.c
+++ b/tools/tpm2_policyrestart.c
@@ -73,7 +73,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("S:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, false);
+                             NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -244,7 +244,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("k:c:P:l:g:L:o:S:q:s:m:f:G:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_rc_decode.c
+++ b/tools/tpm2_rc_decode.c
@@ -244,7 +244,7 @@ static bool on_arg(int argc, char **argv) {
 
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
-    *opts = tpm2_options_new(NULL, 0, NULL, NULL, on_arg, true);
+    *opts = tpm2_options_new(NULL, 0, NULL, NULL, on_arg, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -137,7 +137,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("H:o:c:f:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -159,7 +159,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("k:P:I:o:c:S:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -135,7 +135,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("k:o:c:", ARRAY_LEN(topts), topts,
-                             on_option, on_args, true);
+                             on_option, on_args, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -158,7 +158,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts,
-                             on_option, on_args, false);
+                             on_option, on_args, 0);
 
     ctx.input = stdin;
     ctx.output = stdout;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -285,7 +285,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("k:P:g:m:D:t:s:c:S:f:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -95,7 +95,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("ag:S:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, false);
+                             NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_startup.c
+++ b/tools/tpm2_startup.c
@@ -71,7 +71,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("cs", ARRAY_LEN(topts), topts,
-                             on_option, NULL, false);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -117,7 +117,7 @@ int main(int argc, char *argv[], char *envp[]) {
     }
 
     tpm2_option_flags flags = { .all = 0 };
-    TSS2_TCTI_CONTEXT *tcti;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
     tpm2_option_code rc = tpm2_handle_options(argc, argv, envp, tool_opts, &flags, &tcti);
     if (rc != tpm2_option_code_continue) {
         ret = rc == tpm2_option_code_err ? 1 : 0;
@@ -142,7 +142,10 @@ int main(int argc, char *argv[], char *envp[]) {
     /* figure out the tcti */
 
     /* TODO SAPI INIT */
-    TSS2_SYS_CONTEXT *sapi_context = sapi_ctx_init(tcti);
+    TSS2_SYS_CONTEXT *sapi_context = NULL;
+    if (tcti) {
+        sapi_context = sapi_ctx_init(tcti);
+    }
 
     if (flags.enable_errata) {
         tpm2_errata_init(sapi_context);

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -111,7 +111,7 @@ int main(int argc, char *argv[], char *envp[]) {
         }
     }
 
-    if (argc == 1 && tool_opts && tool_opts->show_usage) {
+    if (argc == 1 && tool_opts && (tool_opts->flags & TPM2_OPTIONS_SHOW_USAGE)) {
         tpm2_print_usage(argv[0], tool_opts);
         return ret;
     }

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -218,7 +218,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("H:P:o:c:S:L:F:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -267,7 +267,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
 
     *opts = tpm2_options_new("k:g:m:D:rs:t:c:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, true);
+                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
Takes an object type + file path as inputs and prints enclosed elements
to stdout in YAML.

Presently only supports TPMS_ATTEST objects for the purpose of printing
TPM generated quotes. Does NOT authenticate input file, which can be
done using other tools -- E.g. see edc3e022 for openssl example.
