### PR TITLE
tpm2_dump_capability.8.in: Typo mistake

### DIFF
--- a/man/tpm2_dump_capability.8.in
+++ b/man/tpm2_dump_capability.8.in
@@ -31,7 +31,7 @@
 .SH NAME
 tpm2_dump_capability \- Display TPM capabilities in a human readable form.
 .SH SYNOPSIS
-.B tpm2_dump_capability [ \fBCOMMON OPTIONS\fR ] [ \fBTCTI OPTIONS\fR ] [ -\fB\-c\fR|\fB\-\-capability\fR]=capability_type
+.B tpm2_dump_capability [ \fBCOMMON OPTIONS\fR ] [ \fBTCTI OPTIONS\fR ] [ \fB\-c\fR|\fB\-\-capability\fR]=capability_type
 .PP
 .SH DESCRIPTION
 Query the TPM for it's capabilities / properties and dump them to the console.


### PR DESCRIPTION
In 2.X branch manual page contains one typo mistake:
Option "--c | --capability" should be "-c | --capability"

(In 3.X branch, tpm2_dump_capability has been renamed to tpm2_getcap, and the manual page has been re-written.)