### PR TITLE
travis.yml: build and install autoconf-archive from source

### DIFF
--- a/.ci/travis-tss-install.sh
+++ b/.ci/travis-tss-install.sh
@@ -33,6 +33,6 @@
 # see: https://github.com/travis-ci/travis-ci/issues/3088
 
 PATH=${PATH}:/usr/local/clang/bin
-(pushd ${TRAVIS_BUILD_DIR}/TPM2.0-TSS && \
+(pushd ${TRAVIS_BUILD_DIR}/tpm2-tss && \
  make install && \
  popd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,18 @@ install:
     - mkdir ibmtpm532 && pushd ibmtpm532 && tar xzf ../ibmtpm532.tar && pushd ./src && make
     - ./tpm_server &
     - popd && popd
-    - git clone --single-branch --branch 1.x https://github.com/01org/TPM2.0-TSS.git
-    - pushd TPM2.0-TSS
+    - wget http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2017.09.28.tar.xz
+    - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01
+    - tar xJf autoconf-archive-2017.09.28.tar.xz && pushd autoconf-archive-2017.09.28
+    - ./configure --prefix=/usr && make -j$(nproc) && sudo make install
+    - popd
+    - git clone --single-branch --branch 1.x https://github.com/intel/tpm2-tss.git
+    - pushd tpm2-tss
     - ./bootstrap && ./configure && make -j$(nproc)
     - sudo ../.ci/travis-tss-install.sh
     - popd
     - sudo ldconfig /usr/local/lib
-    - git clone --single-branch --branch 1.x https://github.com/01org/tpm2-abrmd
+    - git clone --single-branch --branch 1.x https://github.com/intel/tpm2-abrmd
     - pushd tpm2-abrmd
     - ./bootstrap && ./configure --with-dbuspolicydir=/etc/dbus-1/system.d && make -j$(nproc) && sudo make install && popd
     - sudo mkdir -p /var/lib/tpm


### PR DESCRIPTION
Commit 590ed9d2ed21 ("travis: fix autconf dependency on tss") fixed the
tpm2-tss dependency with the AX_CODE_COVERAGE macro, by fetching latest
autoconf-archive and copying the macro into the tpm2-tss source code m4
directory.

But now tpm2-abrmd also uses the macro for code coverage and so instead
of duplicating the same logic, install autoconf-archive in the machine.

While being there, clone the tpm2-{tss,abrmd} repos from the latest URL.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>