### PR TITLE
tpm2_getmanufec: don't attempt to free a pointer that is already NULL

### DIFF
--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -421,9 +421,10 @@ int TPMinitialProvisioning(void)
     LOG_INFO("%s", b64);
 
     rc = RetrieveEndorsementCredentials(b64);
+
+    free(b64);
 out:
     free(hash);
-    free(b64);
     return rc;
 }
 


### PR DESCRIPTION
Commit cc51f9fe188a ("tpm2_getmanufec: fix a memory leak") fixed a memory
leak in TPMinitialProvisioning(), but after this change a pointer that is
already NULL is attempted to be freed.

This doesn't matter since free(3) is a no-op if a pointer is already NULL
but still it's a good practice to free the resources in the inverse order
than were allocated and also makes no sense to attempt to free a NULL ptr.

Reported-by: Jerry Snitselaar <jsnitsel@redhat.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>