### PR TITLE
Fix typo mistake in tpm2_dump_capability.8.in

### DIFF
--- a/man/tpm2_dump_capability.8.in
+++ b/man/tpm2_dump_capability.8.in
@@ -31,7 +31,7 @@
 .SH NAME
 tpm2_dump_capability \- Display TPM capabilities in a human readable form.
 .SH SYNOPSIS
-.B tpm2_dump_capability [ \fBCOMMON OPTIONS\fR ] [ \fBTCTI OPTIONS\fR ] [ -\fB\-c\fR|\fB\-\-capability\fR]=capability_type
+.B tpm2_dump_capability [ \fBCOMMON OPTIONS\fR ] [ \fBTCTI OPTIONS\fR ] [ \fB\-c\fR|\fB\-\-capability\fR]=capability_type
 .PP
 .SH DESCRIPTION
 Query the TPM for it's capabilities / properties and dump them to the console.


### PR DESCRIPTION
Option "--c | --capability" should be "-c | --capability"

Rebased to tpm2-tools branch 2.X.
See also: PR https://github.com/intel/tpm2-tools/pull/735