### PR TITLE
tpm2_clearlock: add tool

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,7 @@ bin_PROGRAMS = \
     tools/tpm2_certify \
     tools/tpm2_changeauth \
     tools/tpm2_clear \
+    tools/tpm2_clearlock \
     tools/tpm2_create \
     tools/tpm2_createpolicy \
     tools/tpm2_createprimary \
@@ -150,6 +151,7 @@ lib_libcommon_a_SOURCES = \
 TOOL_SRC := tools/tpm2_tool.c tools/tpm2_tool.h
 
 tools_tpm2_clear_SOURCES = tools/tpm2_clear.c $(TOOL_SRC)
+tools_tpm2_clearlock_SOURCES = tools/tpm2_clearlock.c $(TOOL_SRC)
 tools_tpm2_create_SOURCES = tools/tpm2_create.c $(TOOL_SRC)
 tools_tpm2_createprimary_SOURCES = tools/tpm2_createprimary.c $(TOOL_SRC)
 tools_tpm2_getcap_SOURCES = tools/tpm2_getcap.c $(TOOL_SRC)
@@ -269,6 +271,7 @@ if HAVE_PANDOC
     man/man1/tpm2_certify.1 \
     man/man1/tpm2_changeauth.1 \
     man/man1/tpm2_clear.1 \
+    man/man1/tpm2_clearlock.1 \
     man/man1/tpm2_create.1 \
     man/man1/tpm2_createpolicy.1 \
     man/man1/tpm2_createprimary.1 \

--- a/man/tpm2_clearlock.1.md
+++ b/man/tpm2_clearlock.1.md
@@ -1,0 +1,59 @@
+% tpm2_clearlock(1) tpm2-tools | General Commands Manual
+%
+% DECEMBER 2017
+
+# NAME
+
+tpm2_clearlock(1) - lock/unlock access to the clear operation.
+
+# SYNOPSIS
+
+`tpm2_clearlock` [OPTIONS]
+
+# DESCRIPTION
+
+tpm2_clearlock(1) - allows a user to enable (unlock) or disable (lock)
+access to the TPM2_Clear() operation. If the lockout password option
+is missing, assume NULL.
+
+# OPTIONS
+
+  * **-c**, **--clear**:
+    specifies the tool should unlock access to the clear command.
+    By default it will try to disable the clear command.
+
+  * **-p**, **--platform**:
+    specifies the tool should operate on the platform hierarchy. By default
+    it operates on the lockout hierarchy.
+
+  * **-L**, **--lockout-passwd**=_LOCKOUT\_PASSWORD_:
+    The lockout authorization value.
+
+    Passwords should follow the password formatting standards, see section
+    "Password Formatting".
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+[password formatting](common/password.md)
+
+# EXAMPLES
+
+Enable the clear command on the platform hierarchy.
+
+```
+tpm2_clearlock -c -p -L lockoutpasswd
+```
+
+Disable the clear command on the lockout hierarchy
+
+```
+tpm2_clearlock
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/test/system/tests/clearlock.sh
+++ b/test/system/tests/clearlock.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#;**********************************************************************;
+#
+# Copyright (c) 2017, Emmanuel Deloget <logout@free.fr>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+
+onerror() {
+    echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
+    exit 1
+}
+trap onerror ERR
+
+cleanup() {
+    tpm2_clearlock -c -p
+}
+trap cleanup EXIT
+
+tpm2_clearlock
+
+tpm2_err=$(tpm2_clear 2>&1 | sed 's/.*: //')
+tpm2_errname=$( [ -z "${tpm2_err}" ] && echo TPM2_RC_SUCCESS || { tpm2_rc_decode ${tpm2_err} | awk '/name/ { print $2 }' ; } )
+test "$tpm2_errname" = "TPM2_RC_DISABLED"
+
+tpm2_clearlock -c -p
+
+tpm2_clear
+
+exit 0

--- a/tools/tpm2_clearlock.c
+++ b/tools/tpm2_clearlock.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2017, Emmanuel Deloget <logout@free.fr>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Intel Corporation nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "log.h"
+#include "tpm2_password_util.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+
+typedef struct clearlock_ctx clearlock_ctx;
+struct clearlock_ctx {
+    bool clear;
+    bool platform;
+    TPMS_AUTH_COMMAND session_data;
+};
+
+static clearlock_ctx ctx = {
+    .clear = false,
+    .platform = false,
+    .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW),
+};
+
+static bool clearlock(TSS2_SYS_CONTEXT *sapi_context) {
+
+    TPMI_RH_CLEAR rh = ctx.platform ? TPM2_RH_PLATFORM : TPM2_RH_LOCKOUT;
+    TPMI_YES_NO disable = ctx.clear ? NO : YES;
+
+    LOG_INFO ("Sending TPM2_ClearControl(%s) command on %s",
+            ctx.clear ? "CLEAR" : "SET",
+            ctx.platform ? "TPM2_RH_PLATFORM" : "TPM2_RH_LOCKOUT");
+
+    TSS2L_SYS_AUTH_COMMAND sessionsData =
+            TSS2L_SYS_AUTH_COMMAND_INIT(1, { ctx.session_data });
+
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
+
+    TSS2_RC rc = TSS2_RETRY_EXP(Tss2_Sys_ClearControl (sapi_context,
+            rh, &sessionsData, disable, &sessionsDataOut));
+
+    if (rc != TPM2_RC_SUCCESS && rc != TPM2_RC_INITIALIZE) {
+        LOG_ERR ("Tss2_Sys_ClearControl failed: 0x%x", rc);
+        return false;
+    }
+
+    LOG_INFO ("Success. TSS2_RC: 0x%x", rc);
+    return true;
+}
+
+static bool on_option(char key, char *value) {
+
+    bool result;
+
+    switch (key) {
+    case 'c':
+        ctx.clear = true;
+        break;
+    case 'p':
+        ctx.platform = true;
+        break;
+    case 'L':
+        result = tpm2_password_util_from_optarg(value, &ctx.session_data.hmac);
+        if (!result) {
+            LOG_ERR("Invalid lockout password, got\"%s\"", value);
+            return false;
+        }
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
+        { "clear",          no_argument,       NULL, 'c' },
+        { "lockout-passwd", required_argument, NULL, 'L' },
+        { "platform",       no_argument,       NULL, 'p' },
+    };
+
+    *opts = tpm2_options_new("cL:p", ARRAY_LEN(topts), topts,
+                             on_option, NULL, false);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    return clearlock(sapi_context) != true;
+}


### PR DESCRIPTION
The tpm2_clearlock tools is used to authorize/forbid the use of
tpm2_clear. It used TPM2_ClearControl() to set or clear disableClear
(when disableClear is set it's not possible to call TPM2_Clear()).

One can check for the status of disableClear using the tpm2_getcap tool.

The clearlock.sh test check for the behavior of this newly added tool.

Fixes: #710

Signed-off-by: Emmanuel Deloget <logout@free.fr>