### PR TITLE
Generic man footer + other fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -311,6 +311,7 @@ endif
 
 MARKDOWN_COMMON_DEPS = \
 	man/common/alg.md \
+	man/common/footer.md \
 	man/common/hash.md \
 	man/common/obj-attrs.md \
 	man/common/object-alg.md \
@@ -348,6 +349,8 @@ man/man1/%.1 : man/%.1.md $(MARKDOWN_COMMON_DEPS)
 	    -e '/\[signature format specifiers\]/d' \
 	    -e '/\[object attribute specifiers\]/r man/common/obj-attrs.md' \
 	    -e '/\[object attribute specifiers\]/d' \
+	    -e '/\[footer\]/r man/common/footer.md' \
+	    -e '/\[footer\]/d' \
 	    < $< | pandoc -s -t man > $@
 
 CLEANFILES = $(man1_MANS)

--- a/man/common/footer.md
+++ b/man/common/footer.md
@@ -1,0 +1,7 @@
+# BUGS
+
+[Github Issues](https://github.com/intel/tpm2-tools/issues)
+
+# HELP
+
+See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -63,11 +63,4 @@ tpm2_activatecredential -H 0x81010002 -k 0x81010001 -P 123abc -e 1a1b1c -X -f <f
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -78,11 +78,4 @@ tpm2_certify -H 0x81010002 -k 0x81010001 -P 0011 -K 00FF -X -g 0x00B -a <fileNam
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -69,10 +69,4 @@ tpm2_changeauth -o newo -e newe -l newl -O oldo -E olde -L oldl
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -51,10 +51,4 @@ tpm2_clear -p
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -1,24 +1,21 @@
-tpm2_clear 1 "DECEMBER 2017" tpm2-tools
-==================================================
+% tpm2_clear(1) tpm2-tools | General Commands Manual
+%
+% DECEMBER 2017
 
-NAME
-----
+# NAME
 
 tpm2_clear(1) - send a clear command to the TPM.
 
-SYNOPSIS
---------
+# SYNOPSIS
 
 `tpm2_clear` [OPTIONS]
 
-DESCRIPTION
------------
+# DESCRIPTION
 
 tpm2_clear(1) - send a clear command to the TPM, i.e. clear the 3 authorization
 values. If the lockout password option is missing, assume NULL.
 
-OPTIONS
--------
+# OPTIONS
 
   * **-p**, **--platform**:
     specifies the tool should operate on the platform hierarchy. By default
@@ -36,8 +33,7 @@ OPTIONS
 
 [password formatting](common/password.md)
 
-EXAMPLES
---------
+# EXAMPLES
 
 Set owner, endorsement and lockout authorizations to an empty auth value:
 
@@ -51,14 +47,14 @@ Clear the authorizations values on the platform hierarchy:
 tpm2_clear -p
 ```
 
-RETURNS
--------
+# RETURNS
+
 0 on success or 1 on failure.
 
-BUGS
-----
+# BUGS
+
 [Github Issues](https://github.com/01org/tpm2-tools/issues)
 
-HELP
-----
+# HELP
+
 See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -93,11 +93,4 @@ tpm2_create -H 0x81010001 -P 123abc -K 456def -X -g sha256 -G keyedhash -I data.
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_createpolicy.1.md
+++ b/man/tpm2_createpolicy.1.md
@@ -68,11 +68,4 @@ Create a authorization policy tied to a specific PCR index:
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -86,11 +86,4 @@ tpm2_createprimary -H o -g sha256 -G ecc -C context.out
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_dictionarylockout.1.md
+++ b/man/tpm2_dictionarylockout.1.md
@@ -55,11 +55,4 @@ tpm2_dictionarylockout -s -n 5 -t 6 -l 7 -p passwd
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -55,11 +55,4 @@ tpm2_encryptdecrypt -k 0x81010001 -P 123abca -X -D NO -I <filePath> -o <filePath
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -59,11 +59,4 @@ tpm2_evictcontrol -A o -H 0x81010002 -S 0x81010002 -P 123abc
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_flushcontext.1.md
+++ b/man/tpm2_flushcontext.1.md
@@ -43,11 +43,4 @@ tpm2_flushcontext --transient-object
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_getcap.1.md
+++ b/man/tpm2_getcap.1.md
@@ -73,11 +73,4 @@ tpm2_getcap --capability="properties-fixed"
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -91,11 +91,4 @@ tpm2_getmanufec -e 1a1b1c -o 1a1b1c -P 123abc -H 0x81010001-g 0x01 -O -N -U -E E
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_getpubak.1.md
+++ b/man/tpm2_getpubak.1.md
@@ -87,11 +87,4 @@ tpm2_getpubak -e 1a1b1c -P 123abc -o 1a1b1c -X -E 0x81010001 -k 0x81010002 -f ./
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_getpubek.1.md
+++ b/man/tpm2_getpubek.1.md
@@ -69,11 +69,4 @@ tpm2_getpubek -e abc123 -o abc123 -P passwd -H 0x81010001 -g rsa -f ek.pub
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_getrandom.1.md
+++ b/man/tpm2_getrandom.1.md
@@ -43,11 +43,4 @@ tpm2_getrandom 8
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_hash.1.md
+++ b/man/tpm2_hash.1.md
@@ -61,11 +61,4 @@ tpm2_hash -H e -g sha1 -o hash.bin -t ticket.bin data.txt
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -72,10 +72,4 @@ cat data.in | tpm2_hmac -k 0x81010002 -g sha256 -o hash.out
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -64,6 +64,7 @@ tpm2_hmac -c key.context -P abc123 -g sha1 -o hash.out << data.in
 ```
 Perform a SHA256 HMAC on _stdin_ and send result and possibly ticket to stdout:
 
+```
 cat data.in | tpm2_hmac -k 0x81010002 -g sha256 -o hash.out
 ```
 

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -54,11 +54,4 @@ RETURNS
 -------
 0 on success or 1 on failure.
 
-BUGS
-----
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-HELP
-----
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_listpersistent.1.md
+++ b/man/tpm2_listpersistent.1.md
@@ -51,10 +51,4 @@ tpm2_listpersistent -g sha256 -G ecc
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -62,10 +62,4 @@ tpm2_load  -H 0x80000000 -P "hex:123abc" -u <pubKeyFileName> -r <privKeyFileName
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -59,10 +59,4 @@ tpm2_loadexternal -H n -u <pubKeyFileName> -r <privKeyFileName> -C object.contex
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -45,10 +45,4 @@ tpm2_makecredential -e <keyFile> -s <secFile> -n <hexString> -o <outFile>
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -66,10 +66,4 @@ tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -t ownerread|ownerwrite|policywri
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_nvlist.1.md
+++ b/man/tpm2_nvlist.1.md
@@ -68,10 +68,4 @@ tpm2_nvlist
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -71,10 +71,4 @@ tpm2_nvread -x 0x1500016 -a 0x40000001 -s 32
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -50,10 +50,4 @@ tpm2_nvreadlock -x 0x1500016 -a 0x40000001 -P passwd
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_nvrelease.1.md
+++ b/man/tpm2_nvrelease.1.md
@@ -51,10 +51,4 @@ tpm2_nvrelease -x 0x1500016 -a 0x40000001 -P passwd
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -64,10 +64,4 @@ tpm2_nvwrite -x 0x1500016 -a 0x40000001 -f nv.data
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_pcrevent.1.md
+++ b/man/tpm2_pcrevent.1.md
@@ -61,11 +61,4 @@ tpm2_pcrevent -i 8 data
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
-
+[footer](common/footer.md)

--- a/man/tpm2_pcrextend.1.md
+++ b/man/tpm2_pcrextend.1.md
@@ -67,10 +67,4 @@ tpm2_pcrextend 4:sha=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15 7:sha256:b5bb9d801
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_pcrlist.1.md
+++ b/man/tpm2_pcrlist.1.md
@@ -87,10 +87,4 @@ tpm2_pcrlist -s
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -89,10 +89,4 @@ tpm2_quote -k 0x81010002 -P "hex:123abc" -L sha1:16,17,18+sha256:16,17,18 -q 11a
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_rc_decode.1.md
+++ b/man/tpm2_rc_decode.1.md
@@ -33,10 +33,4 @@ tpm2_rc_decode 0x100
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_readpublic.1.md
+++ b/man/tpm2_readpublic.1.md
@@ -44,10 +44,4 @@ tpm2_readpublic -H 0x81010002 --opu output.dat
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -63,10 +63,4 @@ tpm2_rsadecrypt -k 0x81010001 -I encrypted.in -o plain.out
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -62,10 +62,4 @@ tpm2_rsaencrypt -k 0x81010001 -I plain.in -o encrypted.out
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_send.1.md
+++ b/man/tpm2_send.1.md
@@ -49,10 +49,4 @@ tpm2_send --tcti=device -i tpm2-command.bin -o tpm2-response.bin
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -86,10 +86,4 @@ tpm2_sign -c key.context -P abc123 -g sha256 -m <filePath> -s <filePath> -t <fil
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_startup.1.md
+++ b/man/tpm2_startup.1.md
@@ -39,10 +39,4 @@ tpm2_startup -c
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -74,10 +74,4 @@ tpm2_unseal -c item.context -L sha1:0,1,2 -F out.dat
 
 0 on success or 1 on failure.
 
-# BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-# HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -85,10 +85,4 @@ tpm2_verifysignature -c key.context -g sha256 -m <filePath> -s <filePath> -t <fi
 
 0 on success or 1 on failure.
 
-BUGS
-
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
-
-HELP
-
-See the [Mailing List](https://lists.01.org/mailman/listinfo/tpm2)
+[footer](common/footer.md)

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -81,7 +81,7 @@ tpm2_verifysignature -k 0x81010001 -D <filePath> -s <filePath> -t <filePath>
 tpm2_verifysignature -c key.context -g sha256 -m <filePath> -s <filePath> -t <filePath>
 ```
 
-RETURNS
+# RETURNS
 
 0 on success or 1 on failure.
 


### PR DESCRIPTION
The series is made of 3 patches

- make tpm2_clear.1.md look like other .1.md files (i.e. use the # syntax for titles instead of underlined titles). 
- fix two small formating issues 
- the big patch: move the BUGS and HELP sections of the man page into a footer.md page and include this page in all other man pages. The BUGS section in this footer.md file points to the new github URL. This fixes #745. 

Best regards, 

-- Emmanuel Deloget