### PR TITLE
Add usage summary text support

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -77,16 +77,6 @@
 #define TPM2TOOLS_ENV_TCTI_NAME      "TPM2TOOLS_TCTI_NAME"
 #define TPM2TOOLS_ENV_ENABLE_ERRATA  "TPM2TOOLS_ENABLE_ERRATA"
 
-struct tpm2_options {
-    struct {
-        tpm2_option_handler on_opt;
-        tpm2_arg_handler on_arg;
-    } callbacks;
-    char *short_opts;
-    size_t len;
-    struct option long_opts[];
-};
-
 tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
         const struct option *long_opts, tpm2_option_handler on_opt,
         tpm2_arg_handler on_arg) {

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -79,7 +79,7 @@
 
 tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
         const struct option *long_opts, tpm2_option_handler on_opt,
-        tpm2_arg_handler on_arg) {
+        tpm2_arg_handler on_arg, bool show_usage) {
 
     tpm2_options *opts = calloc(1, sizeof(*opts) + (sizeof(*long_opts) * len));
     if (!opts) {
@@ -105,6 +105,7 @@ tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
     opts->callbacks.on_opt = on_opt;
     opts->callbacks.on_arg = on_arg;
     opts->len = len;
+    opts->show_usage = show_usage;
     memcpy(opts->long_opts, long_opts, len * sizeof(*long_opts));
 
     return opts;
@@ -139,6 +140,7 @@ bool tpm2_options_cat(tpm2_options **dest, tpm2_options *src) {
 
     d->callbacks.on_arg = src->callbacks.on_arg;
     d->callbacks.on_opt = src->callbacks.on_opt;
+    d->show_usage = src->show_usage;
 
     memcpy(&d->long_opts[d->len], src->long_opts, src->len * sizeof(src->long_opts[0]));
 
@@ -264,7 +266,7 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv, char **envp,
 
     /* handle any options */
     tpm2_options *opts = tpm2_options_new("T:hvVQZ",
-            ARRAY_LEN(long_options), long_options, NULL, NULL);
+            ARRAY_LEN(long_options), long_options, NULL, NULL, true);
     if (!opts) {
         return tpm2_option_code_err;
     }

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -102,6 +102,7 @@ struct tpm2_options {
     } callbacks;
     char *short_opts;
     size_t len;
+    bool show_usage;
     struct option long_opts[];
 };
 
@@ -122,12 +123,14 @@ typedef struct tpm2_options tpm2_options;
  * @param on_arg
  *  An argument handling callback, which may be null if you don't wish
  *  to handle arguments.
+ * @param show_usage
+ *  Whether the tool wants a usage short summary text to be printed.
  * @return
  *  NULL on failure or an initialized tpm2_options object.
  */
 tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
         const struct option *long_opts, tpm2_option_handler on_opt,
-        tpm2_arg_handler on_arg);
+        tpm2_arg_handler on_arg, bool show_usage);
 
 /**
  * Concatenates two tpm2_options objects, with src appended on

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -39,8 +39,6 @@
 
 #include <sapi/tpm20.h>
 
-typedef struct tpm2_options tpm2_options;
-
 typedef union tpm2_option_flags tpm2_option_flags;
 union tpm2_option_flags {
     struct {
@@ -96,6 +94,18 @@ typedef bool (*tpm2_option_handler)(char key, char *value);
  *
  */
 typedef bool (*tpm2_arg_handler)(int argc, char **argv);
+
+struct tpm2_options {
+    struct {
+        tpm2_option_handler on_opt;
+        tpm2_arg_handler on_arg;
+    } callbacks;
+    char *short_opts;
+    size_t len;
+    struct option long_opts[];
+};
+
+typedef struct tpm2_options tpm2_options;
 
 /**
  * The onstart() routine expects a return of NULL or a tpm2_options structure.

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -308,7 +308,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
             && (!ctx.flags.k || !ctx.flags.C) && !ctx.flags.f
             && !ctx.flags.o) {
         LOG_ERR("Expected options (H or c) and (k or C) and f and o");
-        return false;
+        return 1;
     }
 
     if (ctx.file.context) {

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -294,7 +294,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("H:c:k:C:P:e:f:o:X", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -287,7 +287,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("H:k:P:K:g:a:s:C:c:f:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -284,7 +284,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "obj-context",   required_argument, NULL, 'C' },
       { "key-context",   required_argument, NULL, 'c' },
       {  "format",       required_argument, NULL, 'f' },
-      { NULL,            no_argument,       NULL, '\0' }
     };
 
     *opts = tpm2_options_new("H:k:P:K:g:a:s:C:c:f:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -164,7 +164,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("o:e:l:O:E:L:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+                             on_option, NULL, false);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -97,7 +97,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "lockout-passwd", required_argument, NULL, 'L' },
     };
 
-    *opts = tpm2_options_new("pL:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("pL:", ARRAY_LEN(topts), topts, on_option, NULL,
+                             false);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -329,7 +329,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "privfile",             required_argument, NULL, 'r' },
       { "context-parent",       required_argument, NULL, 'c' },
       { "input-session-handle", required_argument, NULL, 'S' },
-      { 0, 0, 0, 0}
     };
 
     setbuf(stdout, NULL);

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -334,7 +334,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setbuf(stdout, NULL);
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
-    *opts = tpm2_options_new("H:P:K:g:G:A:I:L:u:r:c:S:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("H:P:K:g:G:A:I:L:u:r:c:S:", ARRAY_LEN(topts), topts,
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -197,7 +197,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "save-session-context",  required_argument, NULL, 'S' },   
     };
 
-    *opts = tpm2_options_new("f:g:L:F:PaeS:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("f:g:L:F:PaeS:", ARRAY_LEN(topts), topts, on_option,
+                             NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -310,7 +310,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setbuf(stdout, NULL);
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
-    *opts = tpm2_options_new("A:P:K:g:G:C:L:S:H:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("A:P:K:g:G:C:L:S:H:", ARRAY_LEN(topts), topts,
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -305,7 +305,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "policy-file",          required_argument, NULL, 'L' },
       { "object-attributes",    required_argument, NULL, 'A' },
       { "input-session-handle", required_argument, NULL, 'S' },
-      { 0, 0, 0, 0 }
     };
 
     setbuf(stdout, NULL);

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -166,7 +166,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "input-session-handle",  required_argument, NULL, 'S' },
     };
 
-    *opts = tpm2_options_new("n:t:l:P:S:cs", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("n:t:l:P:S:cs", ARRAY_LEN(topts), topts, on_option,
+                             NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -183,7 +183,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     ctx.session_data.sessionHandle = TPM2_RS_PW;
 
-    *opts = tpm2_options_new("k:P:DI:o:c:S:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("k:P:DI:o:c:S:", ARRAY_LEN(topts), topts, on_option,
+                             NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -179,7 +179,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "out-file",             required_argument, NULL, 'o' },
         { "key-context",          required_argument, NULL, 'c' },
         { "input-session-handle", required_argument, NULL, 'S' },
-        { NULL,                   no_argument,       NULL, '\0' }
     };
 
     ctx.session_data.sessionHandle = TPM2_RS_PW;

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -177,7 +177,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "pwda",                 required_argument, NULL, 'P' },
       { "context",              required_argument, NULL, 'c' },
       { "input-session-handle", required_argument, NULL, 'i' },
-      { NULL,                   no_argument,       NULL, '\0' }
     };
 
     ctx.session_data.sessionHandle = TPM2_RS_PW;

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -181,7 +181,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     ctx.session_data.sessionHandle = TPM2_RS_PW;
 
-    *opts = tpm2_options_new("A:H:S:P:c:i:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("A:H:S:P:c:i:", ARRAY_LEN(topts), topts, on_option,
+                             NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -146,7 +146,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     if (ctx.property == (UINT32)-1) {
         LOG_ERR("Expected options H, t, l or s");
-        return false;
+        return 1;
     }
 
     TPMS_CAPABILITY_DATA capability_data = TPMS_CAPABILITY_DATA_EMPTY_INIT;

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -135,7 +135,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("H:tls", ARRAY_LEN(topts), topts,
-                             on_option, NULL);
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -842,7 +842,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "capability", required_argument, NULL, 'c' },
     };
 
-    *opts = tpm2_options_new("c:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("c:", ARRAY_LEN(topts), topts, on_option, NULL,
+                             true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -535,7 +535,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("e:o:H:P:g:f:NO:E:S:i:U", ARRAY_LEN(topts), topts,
-            on_option, on_args);
+                             on_option, on_args, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -469,7 +469,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "ak-name",        required_argument, NULL, 'n' },
     };
 
-    *opts = tpm2_options_new("o:E:e:k:g:D:s:P:f:n:p:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("o:E:e:k:g:D:s:P:f:n:p:", ARRAY_LEN(topts), topts,
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -302,7 +302,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "help",                 no_argument,       NULL, 'h' },
     };
 
-    *opts = tpm2_options_new("e:o:H:P:g:f:p:S:d:hv", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("e:o:H:P:g:f:p:S:d:hv", ARRAY_LEN(topts), topts,
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -109,7 +109,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "out-file",   required_argument, NULL, 'o' },
     };
 
-    *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts, on_option, on_args);
+    *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts, on_option, on_args,
+                             true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -190,7 +190,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     /* set up non-static defaults here */
     ctx.input_file = stdin;
 
-    *opts = tpm2_options_new("H:g:o:t:", ARRAY_LEN(topts), topts, on_option, on_args);
+    *opts = tpm2_options_new("H:g:o:t:", ARRAY_LEN(topts), topts, on_option,
+                             on_args, false);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -282,7 +282,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     ctx.input = stdin;
 
-    *opts = tpm2_options_new("k:P:g:o:S:c:", ARRAY_LEN(topts), topts, on_option, on_args);
+    *opts = tpm2_options_new("k:P:g:o:S:c:", ARRAY_LEN(topts), topts, on_option,
+                             on_args, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -278,7 +278,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "algorithm",            required_argument, NULL, 'g' },
         { "out-file",             required_argument, NULL, 'o' },
         { "input-session-handle", required_argument, NULL, 'S' },
-        { NULL,                   no_argument,       NULL, '\0' }
     };
 
     ctx.input = stdin;

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -299,7 +299,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
      */
     if (!(ctx.flags.k || ctx.flags.c)) {
         LOG_ERR("Must specify options k or c");
-        return false;
+        return rc;
     }
 
     if (ctx.flags.c) {
@@ -308,7 +308,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         if (!result) {
             LOG_ERR("Loading tpm context from file \"%s\" failed.",
                     ctx.context_key_file_path);
-            return false;
+            return rc;
         }
     }
 

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -583,7 +583,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setbuf(stdout, NULL);
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
-    *opts = tpm2_options_new("k:H:f:q:r:A:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("k:H:f:q:r:A:", ARRAY_LEN(topts), topts, on_option,
+                             NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -136,7 +136,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         {"kalg", required_argument, NULL, 'G'},
     };
 
-    *opts = tpm2_options_new("g:G:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("g:G:", ARRAY_LEN(topts), topts, on_option, NULL,
+                             false);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -189,7 +189,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setbuf(stdout, NULL);
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
-    *opts = tpm2_options_new("H:P:u:r:n:C:c:S:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("H:P:u:r:n:C:c:S:", ARRAY_LEN(topts), topts,
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -184,7 +184,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "context",              required_argument, NULL, 'C' },
       { "context-parent",       required_argument, NULL, 'c' },
       { "input-session-handle", required_argument, NULL, 'S' },
-      { 0, 0, 0, 0 }
     };
 
     setbuf(stdout, NULL);

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -150,7 +150,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "context",  required_argument, NULL, 'C'},
     };
 
-    *opts = tpm2_options_new("H:u:r:C:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("H:u:r:C:", ARRAY_LEN(topts), topts, on_option,
+                             NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -161,7 +161,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     if (!(ctx.flags.H && ctx.flags.u)) {
         LOG_ERR("Expected H and u options");
-        return false;
+        return 1;
     }
 
     bool result = load_external(sapi_context);

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -195,7 +195,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {"out-file" ,required_argument, NULL, 'o'},
     };
 
-    *opts = tpm2_options_new("e:s:n:o:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("e:s:n:o:", ARRAY_LEN(topts), topts, on_option,
+                             NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -193,7 +193,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {"sec"     ,required_argument, NULL, 's'},
       {"name"    ,required_argument, NULL, 'n'},
       {"out-file" ,required_argument, NULL, 'o'},
-      {NULL      ,no_argument      , NULL, '\0'}
     };
 
     *opts = tpm2_options_new("e:s:n:o:", ARRAY_LEN(topts), topts, on_option, NULL);

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -206,7 +206,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     if (!ctx.flags.e || !ctx.flags.n || !ctx.flags.o || !ctx.flags.s) {
         LOG_ERR("Expected options e, n, o and s");
-        return false;
+        return 1;
     }
 
     return make_credential_and_save(sapi_context) != true;

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -198,7 +198,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "input-session-handle",   required_argument,  NULL,   'S' },
     };
 
-    *opts = tpm2_options_new("x:a:s:t:P:I:rwdL:S:X", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("x:a:s:t:P:I:rwdL:S:X", ARRAY_LEN(topts), topts,
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -256,7 +256,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("x:a:f:s:o:P:S:L:F:", ARRAY_LEN(topts),
-            topts, on_option, NULL);
+                             topts, on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -135,7 +135,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "input-session-handle", required_argument, NULL, 'S' },
     };
 
-    *opts = tpm2_options_new("x:a:P:Xp:d:S:hv", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("x:a:P:Xp:d:S:hv", ARRAY_LEN(topts), topts,
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -130,7 +130,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "input-session-handle", required_argument, NULL, 'S' },
     };
 
-    *opts = tpm2_options_new("x:a:s:o:P:S:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("x:a:s:o:P:S:", ARRAY_LEN(topts), topts, on_option,
+                             NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -238,7 +238,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("x:a:P:S:o:L:F:", ARRAY_LEN(topts), topts,
-            on_option, on_args);
+                             on_option, on_args, false);
 
     ctx.input_file = stdin;
 

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -337,7 +337,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("i:S:P:", ARRAY_LEN(topts), topts,
-            on_option, on_arg);
+                             on_option, on_arg, false);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -105,8 +105,7 @@ static bool on_arg(int argc, char **argv) {
 
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
-    *opts = tpm2_options_new(NULL, 0, NULL,
-            NULL, on_arg);
+    *opts = tpm2_options_new(NULL, 0, NULL, NULL, on_arg, false);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -402,7 +402,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
      };
 
     *opts = tpm2_options_new("g:o:L:s", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+                             on_option, NULL, false);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -243,7 +243,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("k:c:P:l:g:L:o:S:q:s:m:f:G:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_rc_decode.c
+++ b/tools/tpm2_rc_decode.c
@@ -244,8 +244,7 @@ static bool on_arg(int argc, char **argv) {
 
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
-    *opts = tpm2_options_new(NULL, 0, NULL,
-            NULL, on_arg);
+    *opts = tpm2_options_new(NULL, 0, NULL, NULL, on_arg, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -137,7 +137,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("H:o:c:f:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -157,7 +157,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("k:P:I:o:c:S:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -135,7 +135,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("k:o:c:", ARRAY_LEN(topts), topts,
-            on_option, on_args);
+                             on_option, on_args, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -158,7 +158,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts,
-            on_option, on_args);
+                             on_option, on_args, false);
 
     ctx.input = stdin;
     ctx.output = stdout;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -262,7 +262,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("k:P:g:m:t:s:c:S:f:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_startup.c
+++ b/tools/tpm2_startup.c
@@ -71,7 +71,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("cs", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+                             on_option, NULL, false);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -93,6 +93,30 @@ static TSS2_SYS_CONTEXT* sapi_ctx_init(TSS2_TCTI_CONTEXT *tcti_ctx) {
     return sapi_ctx;
 }
 
+void print_usage(const char *command, struct tpm2_options *tool_opts) {
+    unsigned int i;
+
+    tpm2_tool_output("usage: %s%s%s\n", command,
+                     tool_opts->callbacks.on_opt ? " [OPTIONS]" : "",
+                     tool_opts->callbacks.on_arg ? " ARGUMENTS" : "");
+
+    if (tool_opts->callbacks.on_opt) {
+        for (i = 0; i < tool_opts->len; i++) {
+            struct option *opt = &tool_opts->long_opts[i];
+            tpm2_tool_output("[ -%c | --%s%s]", opt->val, opt->name,
+                             opt->has_arg ? "=VALUE" : "");
+            if ((i + 1) % 4 == 0) {
+                tpm2_tool_output("\n");
+            } else {
+                tpm2_tool_output(" ");
+            }
+        }
+        if (i % 4 != 0) {
+            tpm2_tool_output("\n");
+        }
+    }
+}
+
 /*
  * This program is a template for TPM2 tools that use the SAPI. It does
  * nothing more than parsing command line options that allow the caller to
@@ -109,6 +133,11 @@ int main(int argc, char *argv[], char *envp[]) {
             LOG_ERR("retrieving tool options");
             return 1;
         }
+    }
+
+    if (argc == 1 && tool_opts && tool_opts->show_usage) {
+        print_usage(argv[0], tool_opts);
+        return ret;
     }
 
     tpm2_option_flags flags = { .all = 0 };

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -191,7 +191,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("H:P:o:c:S:L:F:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -188,7 +188,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "input-session-handle", required_argument, NULL, 'S' },
       { "set-list",             required_argument, NULL, 'L' },
       { "pcr-input-file",       required_argument, NULL, 'F' },
-      { NULL,                   no_argument,       NULL, '\0' }
     };
 
     *opts = tpm2_options_new("H:P:o:c:S:L:F:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -267,7 +267,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
 
     *opts = tpm2_options_new("k:g:m:D:rs:t:c:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+                             on_option, NULL, true);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
This pull request adds support to print a short usage summary if the tools are executed with no options.

This is a fix for issue #730.