### PR TITLE
configure.ac: add --with-manpages-help option

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -199,15 +199,10 @@ static char *tcti_get_opts(char *optstr) {
     return &split[1];
 }
 
-static void execute_man (char *prog_name, char *envp[]) {
+static void execute_man(char *prog_name) {
 
     char *manpage = basename(prog_name);
-    char *argv[] = {
-        "/man", // ARGv[0] needs to be something.
-        manpage,
-        NULL
-    };
-    execvpe ("man", argv, envp);
+    execlp("man", "man", manpage, NULL);
     LOG_ERR("Could not execute \"man %s\" error: %s", manpage,
             strerror(errno));
 }
@@ -291,7 +286,7 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv, char **envp,
             tcti_opts = tcti_get_opts(optarg);
             break;
         case 'h':
-            execute_man(argv[0], envp);
+            execute_man(argv[0]);
             show_help = false;
             goto out;
             break;

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -253,6 +253,30 @@ static void show_version (const char *name) {
             tcti_conf);
 }
 
+void tpm2_print_usage(const char *command, struct tpm2_options *tool_opts) {
+    unsigned int i;
+
+    printf("usage: %s%s%s\n", command,
+           tool_opts->callbacks.on_opt ? " [OPTIONS]" : "",
+           tool_opts->callbacks.on_arg ? " ARGUMENTS" : "");
+
+    if (tool_opts->callbacks.on_opt) {
+        for (i = 0; i < tool_opts->len; i++) {
+            struct option *opt = &tool_opts->long_opts[i];
+            printf("[ -%c | --%s%s]", opt->val, opt->name,
+                   opt->has_arg ? "=VALUE" : "");
+            if ((i + 1) % 4 == 0) {
+                printf("\n");
+            } else {
+                printf(" ");
+            }
+        }
+        if (i % 4 != 0) {
+            printf("\n");
+        }
+    }
+}
+
 tpm2_option_code tpm2_handle_options (int argc, char **argv, char **envp,
         tpm2_options *tool_opts, tpm2_option_flags *flags,
         TSS2_TCTI_CONTEXT **tcti) {
@@ -308,7 +332,9 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv, char **envp,
             tcti_opts = tcti_get_opts(optarg);
             break;
         case 'h':
-            execute_man(argv[0]);
+            if (!execute_man(argv[0])) {
+                tpm2_print_usage(argv[0], tool_opts);
+            }
             show_help = false;
             goto out;
             break;

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -186,4 +186,14 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv, char **envp,
         tpm2_options *tool_opts, tpm2_option_flags *flags,
         TSS2_TCTI_CONTEXT **tcti);
 
+/**
+ * Print usage summary for a given tpm2 tool.
+ *
+ * @param command
+ *  The command to print its usage summary text.
+ * @param tool_opts
+ *  The tpm2_options array that contains the tool options to print as a summary.
+ */
+void tpm2_print_usage(const char *command, struct tpm2_options *tool_opts);
+
 #endif /* OPTIONS_H */

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -93,30 +93,6 @@ static TSS2_SYS_CONTEXT* sapi_ctx_init(TSS2_TCTI_CONTEXT *tcti_ctx) {
     return sapi_ctx;
 }
 
-void print_usage(const char *command, struct tpm2_options *tool_opts) {
-    unsigned int i;
-
-    tpm2_tool_output("usage: %s%s%s\n", command,
-                     tool_opts->callbacks.on_opt ? " [OPTIONS]" : "",
-                     tool_opts->callbacks.on_arg ? " ARGUMENTS" : "");
-
-    if (tool_opts->callbacks.on_opt) {
-        for (i = 0; i < tool_opts->len; i++) {
-            struct option *opt = &tool_opts->long_opts[i];
-            tpm2_tool_output("[ -%c | --%s%s]", opt->val, opt->name,
-                             opt->has_arg ? "=VALUE" : "");
-            if ((i + 1) % 4 == 0) {
-                tpm2_tool_output("\n");
-            } else {
-                tpm2_tool_output(" ");
-            }
-        }
-        if (i % 4 != 0) {
-            tpm2_tool_output("\n");
-        }
-    }
-}
-
 /*
  * This program is a template for TPM2 tools that use the SAPI. It does
  * nothing more than parsing command line options that allow the caller to
@@ -136,7 +112,7 @@ int main(int argc, char *argv[], char *envp[]) {
     }
 
     if (argc == 1 && tool_opts && tool_opts->show_usage) {
-        print_usage(argv[0], tool_opts);
+        tpm2_print_usage(argv[0], tool_opts);
         return ret;
     }
 


### PR DESCRIPTION
When the -h / --help option is passwed to the tools, their man pages are
shown. But the tools should be allowed to be used even on machines where
the man pages were not installed.

Currently the tools print a usage text when are executed with no options
but the -h option should be available for those setups and also some of
the tools allow them to be executed with no options (i.e: when using the
standard input to read data).

So add a configure flag to allow the tools -h option to not show the man
pages and install fallback to print the summary text usage instead.

Suggested-by: Emmanuel Deloget <logout@free.fr>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>