### PR TITLE
tpm2_sign : provide -D option to sign a pre-computed hash

### DIFF
--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -46,6 +46,15 @@ data and validation shall indicate that hashed data did not start with
 
     The message file, containing the content to be  digested.
 
+  * **-D**, **--digest**=_DIGEST\_FILE_:
+
+    The digest file that shall be computed using the correct hash
+    algorithm. When this option is specified, a warning is generated and
+    **both the message file (-m) and the validation ticket (-t) are
+    ignored**.
+    You cannot use this option to sign a digest against a restricted
+    signing key.
+
   * **-t**, **--ticket**=_TICKET\_FILE_:
 
     The ticket file, containning the validation structure, optional.

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -240,7 +240,7 @@ static bool on_option(char key, char *value) {
         if (files_does_file_exist(value)) {
             return false;
         }
-        ctx.file_path.sig = optarg;
+        ctx.file_path.sig = value;
         ctx.flags.s = 1;
         break;
     case 'c':
@@ -256,12 +256,12 @@ static bool on_option(char key, char *value) {
             LOG_ERR("Multiple specifications of -C");
             return false;
         }
-        ctx.context_file = optarg;
+        ctx.context_file = value;
         ctx.flags.C = 1;
         break;
     case 'f':
         ctx.flags.f = 1;
-        ctx.sig_fmt = tpm2_parse_signature_format(optarg);
+        ctx.sig_fmt = tpm2_parse_signature_format(value);
 
         if (ctx.sig_fmt == signature_format_err) {
             return false;

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -107,42 +107,42 @@ static bool on_option(char key, char *value) {
     case 'o':
         result = tpm2_password_util_from_optarg(value, &ctx.passwords.owner.new);
         if (!result) {
-            LOG_ERR("Invalid new owner password, got\"%s\"", optarg);
+            LOG_ERR("Invalid new owner password, got\"%s\"", value);
             return false;
         }
         break;
     case 'e':
         result = tpm2_password_util_from_optarg(value, &ctx.passwords.endorse.new);
         if (!result) {
-            LOG_ERR("Invalid new endorse password, got\"%s\"", optarg);
+            LOG_ERR("Invalid new endorse password, got\"%s\"", value);
             return false;
         }
         break;
     case 'l':
         result = tpm2_password_util_from_optarg(value, &ctx.passwords.lockout.new);
         if (!result) {
-            LOG_ERR("Invalid new lockout password, got\"%s\"", optarg);
+            LOG_ERR("Invalid new lockout password, got\"%s\"", value);
             return false;
         }
         break;
     case 'O':
         result = tpm2_password_util_from_optarg(value, &ctx.passwords.owner.old);
         if (!result) {
-            LOG_ERR("Invalid current owner password, got\"%s\"", optarg);
+            LOG_ERR("Invalid current owner password, got\"%s\"", value);
             return false;
         }
         break;
     case 'E':
         result = tpm2_password_util_from_optarg(value, &ctx.passwords.endorse.old);
         if (!result) {
-            LOG_ERR("Invalid current endorse password, got\"%s\"", optarg);
+            LOG_ERR("Invalid current endorse password, got\"%s\"", value);
             return false;
         }
         break;
     case 'L':
         result = tpm2_password_util_from_optarg(value, &ctx.passwords.lockout.old);
         if (!result) {
-            LOG_ERR("Invalid current lockout password, got\"%s\"", optarg);
+            LOG_ERR("Invalid current lockout password, got\"%s\"", value);
             return false;
         }
         break;

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -443,21 +443,21 @@ static bool on_option(char key, char *value) {
     case 'e':
         return_val = tpm2_password_util_from_optarg(value, &ctx.endorse_session_data.hmac);
         if (!return_val) {
-            LOG_ERR("Invalid endorsement password, got\"%s\"", optarg);
+            LOG_ERR("Invalid endorsement password, got\"%s\"", value);
             return false;
         }
         break;
     case 'o':
         return_val = tpm2_password_util_from_optarg(value, &ctx.owner_session_data.hmac);
         if (!return_val) {
-            LOG_ERR("Invalid owner password, got\"%s\"", optarg);
+            LOG_ERR("Invalid owner password, got\"%s\"", value);
             return false;
         }
         break;
     case 'P':
         return_val = tpm2_password_util_from_optarg(value, &ctx.ek_password);
         if (!return_val) {
-            LOG_ERR("Invalid EK password, got\"%s\"", optarg);
+            LOG_ERR("Invalid EK password, got\"%s\"", value);
             return false;
         }
         break;

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -116,7 +116,7 @@ static bool on_option(char key, char *value) {
 
     switch(key) {
     case 'H':
-        if (!tpm2_util_string_to_uint32(optarg, &ctx.parent_handle)) {
+        if (!tpm2_util_string_to_uint32(value, &ctx.parent_handle)) {
                 return false;
         }
         ctx.flags.H = 1;
@@ -129,7 +129,7 @@ static bool on_option(char key, char *value) {
         }
         break;
     case 'u':
-        if(!files_load_public(optarg, &ctx.in_public)) {
+        if(!files_load_public(value, &ctx.in_public)) {
             return false;;
         }
         ctx.flags.u = 1;

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -121,7 +121,7 @@ static bool on_option(char key, char *value) {
         ctx.flags.H = 1;
     break;
     case 'u':
-        if(!files_load_public(optarg, &ctx.public_key)) {
+        if(!files_load_public(value, &ctx.public_key)) {
             return false;;
         }
         ctx.flags.u = 1;

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -178,7 +178,7 @@ static bool on_option(char key, char *value) {
         ctx.flags.n = 1;
     } break;
     case 'o':
-        ctx.out_file_path = optarg;
+        ctx.out_file_path = value;
         ctx.flags.o = 1;
         break;
     }

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -170,10 +170,10 @@ static bool on_option(char key, char *value) {
         }
         break;
     case 'L':
-        ctx.policy_file = optarg;
+        ctx.policy_file = value;
         break;
     case 'S':
-        if (!tpm2_util_string_to_uint32(optarg, &ctx.session_data.sessionHandle)) {
+        if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
             LOG_ERR("Could not convert session handle to number, got: \"%s\"",
                     value);
             return false;

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -172,7 +172,7 @@ static bool on_option(char key, char *value) {
         result = tpm2_util_string_to_uint32(value, &ctx.nv_index);
         if (!result) {
             LOG_ERR("Could not convert NV index to number, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
 
@@ -185,7 +185,7 @@ static bool on_option(char key, char *value) {
         result = tpm2_util_string_to_uint32(value, &ctx.auth_handle);
         if (!result) {
             LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
 
@@ -200,7 +200,7 @@ static bool on_option(char key, char *value) {
     case 'P':
         result = tpm2_password_util_from_optarg(value, &ctx.session_data.hmac);
         if (!result) {
-            LOG_ERR("Invalid handle password, got\"%s\"", optarg);
+            LOG_ERR("Invalid handle password, got\"%s\"", value);
             return false;
         }
         break;
@@ -208,7 +208,7 @@ static bool on_option(char key, char *value) {
         result = tpm2_util_string_to_uint32(value, &ctx.size_to_read);
         if (!result) {
             LOG_ERR("Could not convert size to number, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
         break;
@@ -216,14 +216,14 @@ static bool on_option(char key, char *value) {
         result = tpm2_util_string_to_uint32(value, &ctx.offset);
         if (!result) {
             LOG_ERR("Could not convert offset to number, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
         break;
     case 'S':
         if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
             LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
         break;
@@ -234,7 +234,7 @@ static bool on_option(char key, char *value) {
         ctx.flags.L = 1;
         break;
     case 'F':
-        ctx.raw_pcrs_file = optarg;
+        ctx.raw_pcrs_file = value;
         break;
         /* no default */
     }

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -201,7 +201,7 @@ static bool on_option(char key, char *value) {
         ctx.flags.L = 1;
         break;
     case 'F':
-        ctx.raw_pcrs_file = optarg;
+        ctx.raw_pcrs_file = value;
         break;
     }
 

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -306,7 +306,7 @@ static bool on_option(char key, char *value) {
         if (!result) {
             LOG_ERR(
                     "Could not convert session handle to number, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
     }
@@ -316,7 +316,7 @@ static bool on_option(char key, char *value) {
         bool result = tpm2_password_util_from_optarg(value,
                 &ctx.session_data.hmac);
         if (!result) {
-            LOG_ERR("Invalid key handle password, got\"%s\"", optarg);
+            LOG_ERR("Invalid key handle password, got\"%s\"", value);
             return false;
         }
     }

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -142,7 +142,7 @@ static bool on_option(char key, char *value) {
         k_flag = 1;
         break;
     case 'c':
-        contextFilePath = optarg;
+        contextFilePath = value;
         c_flag = 1;
         break;
 
@@ -162,7 +162,7 @@ static bool on_option(char key, char *value) {
         l_flag = 1;
         break;
     case 'g':
-        pcrSelections.pcrSelections[0].hash = tpm2_alg_util_from_optarg(optarg);
+        pcrSelections.pcrSelections[0].hash = tpm2_alg_util_from_optarg(value);
         if (pcrSelections.pcrSelections[0].hash == TPM2_ALG_ERROR)
         {
             LOG_ERR("Could not convert pcr hash selection, got: \"%s\"", value);
@@ -180,7 +180,7 @@ static bool on_option(char key, char *value) {
         L_flag = 1;
         break;
     case 'o':
-        outFilePath = optarg;
+        outFilePath = value;
         o_flag = 1;
         break;
     case 'q':
@@ -194,26 +194,26 @@ static bool on_option(char key, char *value) {
     case 'S':
          if (!tpm2_util_string_to_uint32(value, &auth_session_handle)) {
              LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                     optarg);
+                     value);
              return false;
          }
          is_auth_session = true;
          break;
     case 's':
-         signature_path = optarg;
+         signature_path = value;
          break;
     case 'm':
-         message_path = optarg;
+         message_path = value;
          break;
     case 'f':
-         sig_format = tpm2_parse_signature_format(optarg);
+         sig_format = tpm2_parse_signature_format(value);
 
          if (sig_format == signature_format_err) {
             return false;
          }
          break;
     case 'G':
-        sig_hash_algorithm = tpm2_alg_util_from_optarg(optarg);
+        sig_hash_algorithm = tpm2_alg_util_from_optarg(value);
         if(sig_hash_algorithm == TPM2_ALG_ERROR) {
             LOG_ERR("Could not convert signature hash algorithm selection, got: \"%s\"", value);
             return false;

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -109,14 +109,14 @@ static bool on_option(char key, char *value) {
         ctx.flags.H = 1;
         break;
     case 'o':
-        ctx.outFilePath = optarg;
+        ctx.outFilePath = value;
         break;
     case 'c':
-        ctx.context_file = optarg;
+        ctx.context_file = value;
         ctx.flags.c = 1;
         break;
     case 'f':
-        ctx.format = tpm2_parse_pubkey_format(optarg);
+        ctx.format = tpm2_parse_pubkey_format(value);
         if (ctx.format == pubkey_format_err) {
             return false;
         }

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -94,7 +94,7 @@ static bool on_option(char key, char *value) {
         bool result = tpm2_util_string_to_uint32(value, &ctx.key_handle);
         if (!result) {
             LOG_ERR("Could not convert key handle to number, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
         ctx.flags.k = 1;
@@ -103,7 +103,7 @@ static bool on_option(char key, char *value) {
     case 'P': {
         bool result = tpm2_password_util_from_optarg(value, &ctx.session_data.hmac);
         if (!result) {
-            LOG_ERR("Invalid key password, got\"%s\"", optarg);
+            LOG_ERR("Invalid key password, got\"%s\"", value);
             return false;
         }
         ctx.flags.P = 1;
@@ -120,22 +120,22 @@ static bool on_option(char key, char *value) {
     }
         break;
     case 'o': {
-        bool result = files_does_file_exist(optarg);
+        bool result = files_does_file_exist(value);
         if (result) {
             return false;
         }
-        ctx.output_file_path = optarg;
+        ctx.output_file_path = value;
         ctx.flags.o = 1;
     }
         break;
     case 'c':
-        ctx.context_key_file = optarg;
+        ctx.context_key_file = value;
         ctx.flags.c = 1;
         break;
     case 'S':
          if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
              LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                     optarg);
+                     value);
              return false;
          }
          break;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -177,7 +177,7 @@ static bool on_option(char key, char *value) {
         bool result = tpm2_util_string_to_uint32(value, &ctx.keyHandle);
         if (!result) {
             LOG_ERR("Could not format key handle to number, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
         ctx.flags.k = 1;
@@ -186,24 +186,24 @@ static bool on_option(char key, char *value) {
     case 'P': {
         bool result = tpm2_password_util_from_optarg(value, &ctx.sessionData.hmac);
         if (!result) {
-            LOG_ERR("Invalid key password, got\"%s\"", optarg);
+            LOG_ERR("Invalid key password, got\"%s\"", value);
             return false;
         }
         ctx.flags.P = 1;
     }
         break;
     case 'g': {
-        ctx.halg = tpm2_alg_util_from_optarg(optarg);
+        ctx.halg = tpm2_alg_util_from_optarg(value);
         if (ctx.halg == TPM2_ALG_ERROR) {
             LOG_ERR("Could not convert to number or lookup algorithm, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
         ctx.flags.g = 1;
     }
         break;
     case 'm':
-        ctx.inMsgFileName = optarg;
+        ctx.inMsgFileName = value;
         ctx.flags.m = 1;
         break;
     case 't': {
@@ -215,28 +215,28 @@ static bool on_option(char key, char *value) {
     }
         break;
     case 's': {
-        bool result = files_does_file_exist(optarg);
+        bool result = files_does_file_exist(value);
         if (result) {
             return false;
         }
-        ctx.outFilePath = optarg;
+        ctx.outFilePath = value;
         ctx.flags.s = 1;
     }
         break;
     case 'c':
-        ctx.contextKeyFile = optarg;
+        ctx.contextKeyFile = value;
         ctx.flags.c = 1;
         break;
     case 'S':
         if (!tpm2_util_string_to_uint32(value, &ctx.sessionData.sessionHandle)) {
             LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
         break;
     case 'f':
         ctx.flags.f = 1;
-        ctx.sig_format = tpm2_parse_signature_format(optarg);
+        ctx.sig_format = tpm2_parse_signature_format(value);
 
         if (ctx.sig_format == signature_format_err) {
             return false;

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -144,7 +144,7 @@ static bool on_option(char key, char *value) {
         bool result = tpm2_util_string_to_uint32(value, &ctx.itemHandle);
         if (!result) {
             LOG_ERR("Could not convert item handle to number, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
         ctx.flags.H = 1;
@@ -153,17 +153,17 @@ static bool on_option(char key, char *value) {
     case 'P': {
         bool result = tpm2_password_util_from_optarg(value, &ctx.sessionData.hmac);
         if (!result) {
-            LOG_ERR("Invalid item handle password, got\"%s\"", optarg);
+            LOG_ERR("Invalid item handle password, got\"%s\"", value);
             return false;
         }
         ctx.flags.P = 1;
     }
         break;
     case 'o':
-        ctx.outFilePath = optarg;
+        ctx.outFilePath = value;
         break;
     case 'c':
-        ctx.contextItemFile = optarg;
+        ctx.contextItemFile = value;
         ctx.flags.c = 1;
         break;
     case 'S': {
@@ -171,7 +171,7 @@ static bool on_option(char key, char *value) {
             &ctx.sessionData.sessionHandle);
         if (!result) {
             LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                    optarg);
+                    value);
             return false;
         }
     }
@@ -183,7 +183,7 @@ static bool on_option(char key, char *value) {
         ctx.flags.L = 1;
         break;
     case 'F':
-        ctx.raw_pcrs_file = optarg;
+        ctx.raw_pcrs_file = value;
         break;
         /* no default */
     }


### PR DESCRIPTION
Intruct tpm2_sign to allow it to handle signing pre-computed hashes. This fixes #753. 

When one wants to use option -D he needs to respect a few conditions: 

* the digest file size should match the selected halg
* the selected signing key shall not be restricted

When option -D is used, options -m and -t are (silently) ignored. 

The patch is bundled with a cleaning patch that remove optarg from the tools code (optarg is a global set by getopt_long() and passed to the tools on_option() as argument value ; thus, it's always available using variable value, and one may consider that optarg is, at this point, an implementation details that should not be shown to users). 

Best regards, 

-- Emmanuel Deloget