### PR TITLE
travis.yml: install liburiparser-dev package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ addons:
     - clang-3.8
     - pandoc
     - lcov
+    - liburiparser-dev
 
 env:
   global:


### PR DESCRIPTION
The tpm2-tss simulator TCTI library uses symbols from Uriparser library,
so install its dev package in the Travis CI instance to build tpm2-tss.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>