### PR TITLE
tools: fix print usage when the program takes no option, no args

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -257,10 +257,10 @@ void tpm2_print_usage(const char *command, struct tpm2_options *tool_opts) {
     unsigned int i;
 
     printf("usage: %s%s%s\n", command,
-           tool_opts->callbacks.on_opt ? " [OPTIONS]" : "",
-           tool_opts->callbacks.on_arg ? " ARGUMENTS" : "");
+           tool_opts && tool_opts->callbacks.on_opt ? " [OPTIONS]" : "",
+           tool_opts && tool_opts->callbacks.on_arg ? " ARGUMENTS" : "");
 
-    if (tool_opts->callbacks.on_opt) {
+    if (tool_opts && tool_opts->callbacks.on_opt) {
         for (i = 0; i < tool_opts->len; i++) {
             struct option *opt = &tool_opts->long_opts[i];
             printf("[ -%c | --%s%s]", opt->val, opt->name,


### PR DESCRIPTION
The symptom is: tpm2_nvlist -h crashes on a system that is missing
man(1).

The reason is: tpm2_nvlist takes no argument at all, and thus tool_opts
is NULL.

In oder to avoid the crash, don't dereference tool_opts when it's not a
valid pointer.

Fixes: #760

Signed-off-by: Emmanuel Deloget <logout@free.fr>