### PR TITLE
lib: fix tpm2_print_usage() when tools have no options/args

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -256,6 +256,10 @@ static void show_version (const char *name) {
 void tpm2_print_usage(const char *command, struct tpm2_options *tool_opts) {
     unsigned int i;
 
+    if (!tool_opts || !tool_opts->show_usage) {
+        return;
+    }
+
     printf("usage: %s%s%s\n", command,
            tool_opts->callbacks.on_opt ? " [OPTIONS]" : "",
            tool_opts->callbacks.on_arg ? " ARGUMENTS" : "");


### PR DESCRIPTION
For tools that takes no options and arguments, its struct tpm2_options is
NULL so trying to access it will lead to a NULL pointer dereference error.

This is checked in the main() function before calling tpm2_print_usage(),
but it was checked when tpm2_print_usage() was added as a fallback to the
--help option when executing the man pager fails.

Instead of relying of the caller to do the check, make tpm2_print_usage()
robust enough to cope with being called with a NULL struct tpm2_options.

After all, it makes no sense to print a usage text for a tool that takes
neither options nor arguments.

Reported-by: Emmanuel Deloget <logout@free.fr>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>