### PR TITLE
Session tools

### DIFF
--- a/.ci/travis-build-and-run-tests.sh
+++ b/.ci/travis-build-and-run-tests.sh
@@ -133,7 +133,7 @@ popd
 pushd ./test/system
 
 # Run the tests on ALL device TCTIs configuration
-PATH=$(pwd)/../../build/tools:${PATH} ./test.sh --plain
+PATH=$(pwd)/../../build/tools:${PATH} ./test.sh -p
 
 # done go back to tpm2-tools directory
 popd

--- a/.ci/travis-build-and-run-tests.sh
+++ b/.ci/travis-build-and-run-tests.sh
@@ -133,7 +133,7 @@ popd
 pushd ./test/system
 
 # Run the tests on ALL device TCTIs configuration
-PATH=$(pwd)/../../build/tools:${PATH} ./test.sh -p
+PATH=$(pwd)/../../build/tools:${PATH} ./test.sh -p -t abrmd
 
 # done go back to tpm2-tools directory
 popd

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,6 +82,7 @@ bin_PROGRAMS = \
     tools/tpm2_pcrextend \
     tools/tpm2_pcrlist \
     tools/tpm2_policypcr \
+    tools/tpm2_policyrestart \
     tools/tpm2_quote \
     tools/tpm2_rc_decode \
     tools/tpm2_readpublic \
@@ -201,6 +202,7 @@ tools_tpm2_import_SOURCES = tools/tpm2_import.c $(TOOL_SRC)
 tools_tpm2_flushcontext_SOURCES = tools/tpm2_flushcontext.c $(TOOL_SRC)
 tools_tpm2_startauthsession_SOURCES = tools/tpm2_startauthsession.c $(TOOL_SRC)
 tools_tpm2_policypcr_SOURCES = tools/tpm2_policypcr.c $(TOOL_SRC)
+tools_tpm2_policyrestart_SOURCES = tools/tpm2_policyrestart.c $(TOOL_SRC)
 
 if UNIT
 TESTS = $(check_PROGRAMS)
@@ -326,6 +328,7 @@ if HAVE_PANDOC
     man/man1/tpm2_pcrextend.1 \
     man/man1/tpm2_pcrlist.1 \
     man/man1/tpm2_policypcr.1 \
+    man/man1/tpm2_policyrestart.1 \
     man/man1/tpm2_quote.1 \
     man/man1/tpm2_rc_decode.1 \
     man/man1/tpm2_readpublic.1 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -261,7 +261,9 @@ test_unit_test_tpm2_errata_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
 test_unit_test_tpm2_errata_SOURCES  = test/unit/test_tpm2_errata.c
 
 test_unit_test_tpm2_session_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_test_tpm2_session_LDFLAGS  = -Wl,--wrap=Tss2_Sys_StartAuthSession
+test_unit_test_tpm2_session_LDFLAGS  = -Wl,--wrap=Tss2_Sys_StartAuthSession \
+                                       -Wl,--wrap=Tss2_Sys_ContextSave \
+                                       -Wl,--wrap=Tss2_Sys_ContextLoad
 test_unit_test_tpm2_session_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON) $(LDADD)
 test_unit_test_tpm2_session_SOURCES  = test/unit/test_tpm2_session.c
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,6 +88,7 @@ bin_PROGRAMS = \
     tools/tpm2_rsaencrypt \
     tools/tpm2_send \
     tools/tpm2_sign \
+    tools/tpm2_startauthsession \
     tools/tpm2_startup \
     tools/tpm2_unseal \
     tools/tpm2_verifysignature
@@ -197,6 +198,7 @@ tools_tpm2_pcrevent_SOURCES = tools/tpm2_pcrevent.c $(TOOL_SRC)
 tools_tpm2_rc_decode_SOURCES = tools/tpm2_rc_decode.c $(TOOL_SRC)
 tools_tpm2_import_SOURCES = tools/tpm2_import.c $(TOOL_SRC)
 tools_tpm2_flushcontext_SOURCES = tools/tpm2_flushcontext.c $(TOOL_SRC)
+tools_tpm2_startauthsession_SOURCES = tools/tpm2_startauthsession.c $(TOOL_SRC)
 
 if UNIT
 TESTS = $(check_PROGRAMS)
@@ -324,6 +326,7 @@ if HAVE_PANDOC
     man/man1/tpm2_rsaencrypt.1 \
     man/man1/tpm2_send.1 \
     man/man1/tpm2_sign.1 \
+    man/man1/tpm2_startauthsession.1 \
     man/man1/tpm2_startup.1 \
     man/man1/tpm2_unseal.1 \
     man/man1/tpm2_verifysignature.1

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,7 @@ bin_PROGRAMS = \
     tools/tpm2_pcrevent \
     tools/tpm2_pcrextend \
     tools/tpm2_pcrlist \
+    tools/tpm2_policypcr \
     tools/tpm2_quote \
     tools/tpm2_rc_decode \
     tools/tpm2_readpublic \
@@ -199,6 +200,7 @@ tools_tpm2_rc_decode_SOURCES = tools/tpm2_rc_decode.c $(TOOL_SRC)
 tools_tpm2_import_SOURCES = tools/tpm2_import.c $(TOOL_SRC)
 tools_tpm2_flushcontext_SOURCES = tools/tpm2_flushcontext.c $(TOOL_SRC)
 tools_tpm2_startauthsession_SOURCES = tools/tpm2_startauthsession.c $(TOOL_SRC)
+tools_tpm2_policypcr_SOURCES = tools/tpm2_policypcr.c $(TOOL_SRC)
 
 if UNIT
 TESTS = $(check_PROGRAMS)
@@ -319,6 +321,7 @@ if HAVE_PANDOC
     man/man1/tpm2_pcrevent.1 \
     man/man1/tpm2_pcrextend.1 \
     man/man1/tpm2_pcrlist.1 \
+    man/man1/tpm2_policypcr.1 \
     man/man1/tpm2_quote.1 \
     man/man1/tpm2_rc_decode.1 \
     man/man1/tpm2_readpublic.1 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -263,7 +263,9 @@ test_unit_test_tpm2_errata_SOURCES  = test/unit/test_tpm2_errata.c
 test_unit_test_tpm2_session_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_tpm2_session_LDFLAGS  = -Wl,--wrap=Tss2_Sys_StartAuthSession \
                                        -Wl,--wrap=Tss2_Sys_ContextSave \
-                                       -Wl,--wrap=Tss2_Sys_ContextLoad
+                                       -Wl,--wrap=Tss2_Sys_ContextLoad \
+                                       -Wl,--wrap=Tss2_Sys_PolicyRestart
+
 test_unit_test_tpm2_session_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON) $(LDADD)
 test_unit_test_tpm2_session_SOURCES  = test/unit/test_tpm2_session.c
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -154,7 +154,7 @@ bool files_save_bytes_to_file(const char *path, UINT8 *buf, UINT16 size) {
 #define CONTEXT_VERSION 1
 
 bool files_save_tpm_context_to_file(TSS2_SYS_CONTEXT *sysContext, TPM2_HANDLE handle,
-        const char *path) {
+        FILE *stream) {
 
     TPMS_CONTEXT context;
 
@@ -163,13 +163,6 @@ bool files_save_tpm_context_to_file(TSS2_SYS_CONTEXT *sysContext, TPM2_HANDLE ha
         LOG_ERR(
                 "Tss2_Sys_ContextSave: Saving handle 0x%x context failed. TPM Error:0x%x",
                 handle, rval);
-        return false;
-    }
-
-    FILE *f = fopen(path, "w+b");
-    if (!f) {
-        LOG_ERR("Error opening file \"%s\" due to error: %s", path,
-                strerror(errno));
         return false;
     }
 
@@ -182,63 +175,71 @@ bool files_save_tpm_context_to_file(TSS2_SYS_CONTEXT *sysContext, TPM2_HANDLE ha
      * U16 contextBlobLength
      * BYTE[] contextBlob
      */
-    bool result = files_write_header(f, CONTEXT_VERSION);
+    bool result = files_write_header(stream, CONTEXT_VERSION);
     if (!result) {
-        LOG_ERR("Could not write header for file: \"%s\"", path);
+        LOG_ERR("Could not write context file header");
         goto out;
     }
 
     // UINT32
-    result = files_write_32(f, context.hierarchy);
+    result = files_write_32(stream, context.hierarchy);
     if (!result) {
-        LOG_ERR("Could not write hierarchy for file: \"%s\"", path);
+        LOG_ERR("Could not write hierarchy");
         goto out;
     }
 
-    result = files_write_32(f, context.savedHandle);
+    result = files_write_32(stream, context.savedHandle);
     if (!result) {
-        LOG_ERR("Could not write savedHandle for file: \"%s\"", path);
+        LOG_ERR("Could not write savedHandle");
         goto out;
     }
 
     // UINT64
-    result = files_write_64(f, context.sequence);
+    result = files_write_64(stream, context.sequence);
     if (!result) {
-        LOG_ERR("Could not write sequence for file: \"%s\"", path);
+        LOG_ERR("Could not write sequence");
         goto out;
     }
 
     // U16 LENGTH
-    result = files_write_16(f, context.contextBlob.size);
+    result = files_write_16(stream, context.contextBlob.size);
     if (!result) {
-        LOG_ERR("Could not write contextBob size file: \"%s\"", path);
+        LOG_ERR("Could not write contextBob size");
         goto out;
     }
 
     // BYTE[] contextBlob
-    result = files_write_bytes(f, context.contextBlob.buffer,
+    result = files_write_bytes(stream, context.contextBlob.buffer,
             context.contextBlob.size);
     if (!result) {
-        LOG_ERR("Could not write contextBlob buffer for file: \"%s\"", path);
+        LOG_ERR("Could not write contextBlob buffer");
     }
     /* result is set by file_write_bytes() */
 
 out:
-    fclose(f);
     return result;
 }
 
-bool files_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context,
-        TPM2_HANDLE *handle, const char *path) {
+bool files_save_tpm_context_to_path(TSS2_SYS_CONTEXT *sysContext, TPM2_HANDLE handle,
+        const char *path) {
 
-    TSS2_RC rval;
-
-    FILE *f = fopen(path, "rb");
+    FILE *f = fopen(path, "w+b");
     if (!f) {
         LOG_ERR("Error opening file \"%s\" due to error: %s", path,
                 strerror(errno));
         return false;
     }
+
+    bool result = files_save_tpm_context_to_file(sysContext, handle, f);
+    fclose(f);
+    return result;
+}
+
+
+bool files_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context,
+        TPM2_HANDLE *handle, FILE *fstream) {
+
+    TSS2_RC rval;
 
     /*
      * Reading the TPMS_CONTEXT structure to disk, format:
@@ -251,15 +252,15 @@ bool files_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context,
      */
     UINT32 version;
     TPMS_CONTEXT context;
-    bool result = files_read_header(f, &version);
+    bool result = files_read_header(fstream, &version);
     if (!result) {
         LOG_WARN(
-                "The tpm context file \"%s\" does not appear in the proper format, assuming old format, this will be converted on the next save.",
-                path);
-        rewind(f);
-        result = files_read_bytes(f, (UINT8 *) &context, sizeof(context));
+            "The loaded tpm context does not appear to be in the proper format,"
+            "assuming old format, this will be converted on the next save.");
+        rewind(fstream);
+        result = files_read_bytes(fstream, (UINT8 *) &context, sizeof(context));
         if (!result) {
-            LOG_ERR("Could not load file \"%s\" into tpm context", path);
+            LOG_ERR("Could not load tpm context file");
             goto out;
         }
         /* Success load the context into the TPM */
@@ -273,25 +274,25 @@ bool files_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context,
         goto out;
     }
 
-    result = files_read_32(f, &context.hierarchy);
+    result = files_read_32(fstream, &context.hierarchy);
     if (!result) {
         LOG_ERR("Error reading hierarchy!");
         goto out;
     }
 
-    result = files_read_32(f, &context.savedHandle);
+    result = files_read_32(fstream, &context.savedHandle);
     if (!result) {
         LOG_ERR("Error reading savedHandle!");
         goto out;
     }
 
-    result = files_read_64(f, &context.sequence);
+    result = files_read_64(fstream, &context.sequence);
     if (!result) {
         LOG_ERR("Error reading sequence!");
         goto out;
     }
 
-    result = files_read_16(f, &context.contextBlob.size);
+    result = files_read_16(fstream, &context.contextBlob.size);
     if (!result) {
         LOG_ERR("Error reading contextBlob.size!");
         goto out;
@@ -306,7 +307,7 @@ bool files_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context,
         goto out;
     }
 
-    result = files_read_bytes(f, context.contextBlob.buffer,
+    result = files_read_bytes(fstream, context.contextBlob.buffer,
             context.contextBlob.size);
     if (!result) {
         LOG_ERR("Error reading contextBlob.size!");
@@ -324,6 +325,21 @@ load_to_tpm:
     result = true;
 
 out:
+    return result;
+}
+
+bool files_load_tpm_context_from_path(TSS2_SYS_CONTEXT *sapi_context,
+        TPM2_HANDLE *handle, const char *path) {
+
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        LOG_ERR("Error opening file \"%s\" due to error: %s", path,
+                strerror(errno));
+        return false;
+    }
+
+    bool result = files_load_tpm_context_from_file(sapi_context, handle, f);
+
     fclose(f);
     return result;
 }

--- a/lib/files.h
+++ b/lib/files.h
@@ -93,7 +93,21 @@ bool files_save_bytes_to_file(const char *path, UINT8 *buf, UINT16 size);
  * @return
  *  True on success, False on error.
  */
-bool files_save_tpm_context_to_file(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE handle, const char *path);
+bool files_save_tpm_context_to_path(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE handle, const char *path);
+
+/**
+ * Like files_save_tpm_context_to_path() but saves a tpm session to a FILE stream.
+ * @param sapi_context
+ *  The system api context
+ * @param handle
+ *  The object handle for the object to save.
+ * @param stream
+ *  The FILE stream to save too.
+ * @return
+ *  True on success, False on error.
+ */
+bool files_save_tpm_context_to_file(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE handle,
+        FILE *stream);
 
 /**
  * Loads a TPM object context from disk.
@@ -106,7 +120,21 @@ bool files_save_tpm_context_to_file(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE 
  * @return
  *  True on Success, false on error.
  */
-bool files_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE *handle, const char *path);
+bool files_load_tpm_context_from_path(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE *handle, const char *path);
+
+/**
+ * Like files_load_tpm_context_from_path() but loads the context from a FILE stream.
+ * @param sapi_context
+ *  The system API context
+ * @param handle
+ *  The object handle that was saved.
+ * @param stream
+ *  The FILE stream to read from.
+ * @return
+ *  True on success, False on error.
+ */
+bool files_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context,
+        TPM2_HANDLE *handle, FILE *stream);
 
 /**
  * Serializes a TPM2B_PUBLIC to the file path provided.

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -166,7 +166,7 @@ static bool tpm2_policy_pcr_build(TSS2_SYS_CONTEXT *sapi_context,
     }
 
     // Call the PolicyPCR command
-    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(
+    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_handle(
             policy_session);
 
     TSS2_RC rval = Tss2_Sys_PolicyPCR(sapi_context, handle,
@@ -199,7 +199,7 @@ bool tpm2_policy_get_digest(TSS2_SYS_CONTEXT *sapi_context,
         tpm2_session *session,
         TPM2B_DIGEST *policy_digest) {
 
-    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(session);
+    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_handle(session);
 
     TPM2_RC rval = Tss2_Sys_PolicyGetDigest(sapi_context, handle,
     NULL, policy_digest, NULL);

--- a/lib/tpm2_session.c
+++ b/lib/tpm2_session.c
@@ -110,7 +110,7 @@ TPMI_ALG_HASH tpm2_session_get_authhash(tpm2_session *session) {
     return session->input->authHash;
 }
 
-TPMI_SH_AUTH_SESSION tpm2_session_get_session_handle(tpm2_session *session) {
+TPMI_SH_AUTH_SESSION tpm2_session_get_handle(tpm2_session *session) {
     return session->output.session_handle;
 }
 
@@ -271,7 +271,7 @@ bool tpm2_session_save(TSS2_SYS_CONTEXT *sapi_context, tpm2_session *session,
         return false;
     }
 
-    TPM2_HANDLE handle = tpm2_session_get_session_handle(session);
+    TPM2_HANDLE handle = tpm2_session_get_handle(session);
     result = files_save_tpm_context_to_file(sapi_context, handle, mem);
     if (!result) {
         goto out;
@@ -335,7 +335,7 @@ out:
 
 bool tpm2_session_restart(TSS2_SYS_CONTEXT *sapi_context, tpm2_session *s) {
 
-    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(s);
+    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_handle(s);
 
     TSS2_RC rval = Tss2_Sys_PolicyRestart(sapi_context, handle, NULL, NULL);
     if (rval != TPM2_RC_SUCCESS) {

--- a/lib/tpm2_session.c
+++ b/lib/tpm2_session.c
@@ -317,7 +317,6 @@ bool tpm2_session_save(TSS2_SYS_CONTEXT *sapi_context, tpm2_session *session,
      }
 
      /* result is set by files_write_32() */
-
 out:
     if (mem) {
         fclose(mem);

--- a/lib/tpm2_session.c
+++ b/lib/tpm2_session.c
@@ -114,6 +114,10 @@ TPMI_SH_AUTH_SESSION tpm2_session_get_session_handle(tpm2_session *session) {
     return session->output.session_handle;
 }
 
+TPM2_SE tpm2_session_get_type(tpm2_session *session) {
+    return session->input->session_type;
+}
+
 //
 // This is a wrapper function around the TPM2_StartAuthSession command.
 // It performs the command, calculates the session key, and updates a

--- a/lib/tpm2_session.c
+++ b/lib/tpm2_session.c
@@ -329,3 +329,15 @@ out:
 
     return result;
 }
+
+bool tpm2_session_restart(TSS2_SYS_CONTEXT *sapi_context, tpm2_session *s) {
+
+    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(s);
+
+    TSS2_RC rval = Tss2_Sys_PolicyRestart(sapi_context, handle, NULL, NULL);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_ERR("PolicyRestart: 0x%x", rval);
+    }
+
+    return rval == TPM2_RC_SUCCESS;
+}

--- a/lib/tpm2_session.h
+++ b/lib/tpm2_session.h
@@ -180,6 +180,18 @@ bool tpm2_session_save(TSS2_SYS_CONTEXT *sapi_context, tpm2_session *session,
 tpm2_session *tpm2_session_restore(const char *path);
 
 /**
+ * restarts the session to it's initial state via a call to
+ * Tss2_Sys_PolicyRestart().
+ * @param sapi_context
+ *  The system api context
+ * @param s
+ *  The session
+ * @return
+ *  true on success, false otherwise.
+ */
+bool tpm2_session_restart(TSS2_SYS_CONTEXT *sapi_context, tpm2_session *s);
+
+/**
  * Frees a tpm2_sessio but DOES NOT FLUSH the handle. Frees the associated
  * tpm2_session_data object as well.
  * @param session

--- a/lib/tpm2_session.h
+++ b/lib/tpm2_session.h
@@ -131,7 +131,7 @@ TPMI_ALG_HASH tpm2_session_get_authhash(tpm2_session *session);
  * @return
  *  The session handle.
  */
-TPMI_SH_AUTH_SESSION tpm2_session_get_session_handle(tpm2_session *session);
+TPMI_SH_AUTH_SESSION tpm2_session_get_handle(tpm2_session *session);
 
 /**
  * Retrieves the type of session, ie trial or policy session.

--- a/lib/tpm2_session.h
+++ b/lib/tpm2_session.h
@@ -134,6 +134,26 @@ TPMI_ALG_HASH tpm2_session_get_authhash(tpm2_session *session);
 TPMI_SH_AUTH_SESSION tpm2_session_get_session_handle(tpm2_session *session);
 
 /**
+ * Retrieves the type of session, ie trial or policy session.
+ * @param session
+ * @return
+ *  The type of the session, either TPM2_SE_HMAC, TPM2_SE_POLICY or
+ *  TPM2_SE_TRIAL.
+ */
+TPM2_SE tpm2_session_get_type(tpm2_session *session);
+
+/**
+ * True if a session is of type TPM2_SE_TRIAL
+ * @param session
+ *  The session to check the type of.
+ * @return
+ *  True if a session is of type TPM2_SE_TRIAL, false otherwise.
+ */
+static inline bool tpm2_session_is_trial(tpm2_session *session) {
+    return tpm2_session_get_type(session) == TPM2_SE_TRIAL;
+}
+
+/**
  * Starts a session with the tpm via Tss2_Sys_StartAuthSession().
  * @param sapi_context
  *  The system api context.

--- a/lib/tpm2_session.h
+++ b/lib/tpm2_session.h
@@ -28,6 +28,8 @@
 #ifndef SRC_TPM2_SESSION_H_
 #define SRC_TPM2_SESSION_H_
 
+#include <stdbool.h>
+
 #include <sapi/tpm20.h>
 
 typedef struct tpm2_session_data tpm2_session_data;
@@ -145,6 +147,37 @@ TPMI_SH_AUTH_SESSION tpm2_session_get_session_handle(tpm2_session *session);
  */
 tpm2_session *tpm2_session_new(TSS2_SYS_CONTEXT *sapi_context,
         tpm2_session_data *data);
+
+/**
+ * Saves session data to disk allowing tpm2_session_from_file() to
+ * restore the session.
+ *
+ * @Note
+ * This is accomplished by calling:
+ *   - Tss2_Sys_ContextSave - marks to some RMs like tpm2-abrmd not to flush this session
+ *                            handle on client disconnection.
+ *   - Tss2_Sys_ContextLoad - restores the session so it can be used.
+ *   - Saving a custom file format at path - records the handle and algorithm.
+ * @param session
+ *  The session context to save
+ * @param sapi_context
+ *  The system api context
+ * @param path
+ *  The path to save the session context too.
+ * @return
+ *  True on success, false otherwise.
+ */
+bool tpm2_session_save(TSS2_SYS_CONTEXT *sapi_context, tpm2_session *session,
+        const char *path);
+
+/**
+ * Restores a session saved with tpm2_session_save().
+ * @param path
+ *  The path to restore from.
+ * @return
+ *  NULL on failure or a session pointer on success.
+ */
+tpm2_session *tpm2_session_restore(const char *path);
 
 /**
  * Frees a tpm2_sessio but DOES NOT FLUSH the handle. Frees the associated

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -67,7 +67,7 @@
 #define TPMS_AUTH_COMMAND_INIT(session_handle) { \
         .sessionHandle = session_handle,\
 	    .nonce = TPM2B_EMPTY_INIT, \
-	    .sessionAttributes = 0, \
+	    .sessionAttributes = TPMA_SESSION_CONTINUESESSION, \
 	    .hmac = TPM2B_EMPTY_INIT \
     }
 

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -64,8 +64,10 @@ These options for creating the tpm entity:
   * **-r**, **--privfile**=_OUTPUT\_PRIVATE\_FILE_:
     The output file which contains the sensitive portion of the object, optional.
 
-* **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option. This session
+    is used in lieu of starting a session and using the PCR policy options.
 
 [common options](common/options.md)
 

--- a/man/tpm2_createpolicy.1.md
+++ b/man/tpm2_createpolicy.1.md
@@ -39,16 +39,9 @@ These options control creating the policy authorization session:
     Optional Path or Name of the file containing expected pcr values for the
     specified index. Default is to read the current PCRs per the set list.
 
-  * **-e**, **--extend-policy-session**:
-    Retains the policy session at the end of operation.
-
   * **-a**, **--auth-policy-session**:
     Start a policy session of type **TPM_SE_POLICY**. Default without this option
     is **TPM_SE_TRIAL**.
-
-  * **-S**, **--save-session-context**:_CONTEXT\_FILE_:
-    An optional file used to store the session context created by either -e
-    or -a.
 
 [common options](common/options.md)
 

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -59,8 +59,9 @@ will create and load a Primary Object. The sensitive area is not returned.
 
     `TPMA_OBJECT_RESTRICTED|TPMA_OBJECT_DECRYPT|TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH`
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
 [common options](common/options.md)
 

--- a/man/tpm2_dictionarylockout.1.md
+++ b/man/tpm2_dictionarylockout.1.md
@@ -37,8 +37,9 @@ dictionary-attack-lockout state, if any passwd option is missing, assume NULL.
     specifies the maximum number of allowed authentication attempts on
     DA-protected-object; after which DA is activated.
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
 [common options](common/options.md)
 

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -34,8 +34,10 @@ specified symmetric key.
   * **-I**, **--in-file**=_INPUT\_FILE_:
     Input file path containing data for decrypt or encrypt operation.
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option. This session
+    is used in lieu of starting a session and using the PCR policy options.
 
 [common options](common/options.md)
 

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -34,12 +34,16 @@ be evicted.
   * **-c**, **--context**=_OBJECT\_CONTEXT\_FILE_:
     Filename for object context.
 
-  * **-S**, **--persistent**=_PERSISTENT\_HANDLE_:
+  * **-p**, **--persistent**=_PERSISTENT\_HANDLE_:
     The persistent handle for the object handle specified via _HANDLE_.
 
   * **-P**, **--pwda**=_AUTH\_PASSWORD_:
     authorization password, optional. Passwords should follow the
     "password formatting standards, see section "Password Formatting".
+
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
 [common options](common/options.md)
 

--- a/man/tpm2_flushcontext.1.md
+++ b/man/tpm2_flushcontext.1.md
@@ -28,6 +28,11 @@
   * **-s**, **--saved-session**:
     Remove all saved sessions.
 
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Obtain handle to flush from a session file. A session file is generated
+    from **tpm2_startauthsession**(1)'s **-S** option.
+
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)
@@ -37,6 +42,12 @@
 ```
 tpm2_flushcontext -H 0x80000000
 tpm2_flushcontext --transient-object
+```
+
+Flushing a context via a session file
+```
+tpm2_startauthsession -S session.dat
+tpm2_flushcontext -S session.dat
 ```
 
 # RETURNS

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -60,8 +60,9 @@ server.
     specifies to attempt connecting with the  TPM manufacturer provisioning server
     with SSL_NO_VERIFY option.
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
 
 [common options](common/options.md)

--- a/man/tpm2_getpubek.1.md
+++ b/man/tpm2_getpubek.1.md
@@ -48,8 +48,9 @@ Refer to:
     binary data structure corresponding to the TPM2B_PUBLIC struct in the
     specification.
 
-  * **-S**, **--input-session-handle**=_SESSION_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
 [common options](common/options.md)
 

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -37,8 +37,9 @@ _FILE_ is not specified, then data is read from stdin.
   * **-o**, **--out-file**=_OUT\_FILE_
     Optional file record of the HMAC result. Defaults to stdout.
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
 [common options](common/options.md)
 

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -39,8 +39,9 @@ into the TPM.
   * **-C**, **--context**=_CONTEXT\_FILE_:
     An optional file to save the object context to.
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
 [common options](common/options.md)
 

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -44,8 +44,9 @@
   * **-L**, **--policy-file**=_POLICY\_FILE_:
     Specifies the policy digest file for policy based authorizations.
 
-  * **-S**, **--input-session-handle**=_SIZE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
 [common options](common/options.md)
 

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -39,8 +39,9 @@
   * **-o**, **--offset**=_OFFSET_:
     The offset within the NV index to start reading from.
 
-  * **-S**, **--input-session-handle**=_SIZE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
   * **-L**, **--set-list**==_PCR\_SELECTION\_LIST_:
 

--- a/man/tpm2_nvrelease.1.md
+++ b/man/tpm2_nvrelease.1.md
@@ -32,8 +32,9 @@ defined with tpm2_nvdefine(1).
     specifies the password of authHandle. Passwords should follow the
     "password formatting standards, see section "Password Formatting".
 
-  * **-S**, **--input-session-handle**=_SIZE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
 [common options](common/options.md)
 

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -32,8 +32,9 @@ If _FILE_ is not specified, it defaults to stdin.
     specifies the password of authHandle. Passwords should follow the
     "password formatting standards, see section "Password Formatting".
 
-  * **-S**, **--input-session-handle**=_SIZE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
   * **-L**, **--set-list**==_PCR\_SELECTION\_LIST_:
 

--- a/man/tpm2_pcrevent.1.md
+++ b/man/tpm2_pcrevent.1.md
@@ -33,8 +33,9 @@ These options control extending the pcr:
     Not only compute the hash digests on _FILE_, also extend the pcr given by
     _INDEX_ for all supported hash algorithms.
 
-  * **-S**, **--input-session-handle**=_SESSION_HANDLE_:
-    Use _SESSION_HANDLE_ for providing an authorization session for the pcr
+    * **-S**, **--session**=_SESSION\_FILE_:
+    A session file from **tpm2_startauthsession**(1)'s **-S** option.
+    Use _SESSION\_FILE_ for providing an authorization session for the PCR
     specified by _INDEX_.
     It is an error to specify **-S** without specifying a pcr index with **-i**.
 

--- a/man/tpm2_policypcr.1.md
+++ b/man/tpm2_policypcr.1.md
@@ -1,0 +1,93 @@
+% tpm2_policypcr(1) tpm2-tools | General Commands Manual
+%
+% JANUARY 2018
+
+# NAME
+
+**tpm2_policypcr**(1) - Perform a policyPCR event with the TPM.
+
+# SYNOPSIS
+
+**tpm2_policypcr** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tpm2_policypcr**(1) generates a policy PCR event with the TPM. It is similair
+to **tpm2_createpolicy**(1), however, it expects a session to be already
+established via **tpm2_startauthsession**(1).
+
+# OPTIONS
+
+  * **-f**, **--policy-file**=_POLICY\_FILE_:
+    File to save the policy digest.
+
+  * **-F**, **--pcr-input-file**=_PCR\_FILE_:
+    Optional Path or Name of the file containing expected pcr values for the
+    specified index. Default is to read the current PCRs per the set list.
+
+  * **-L**, **--set-list**=_PCR\_LIST_:
+    The list of pcr banks and selected PCRs' ids (0~23) for each bank.
+
+  * **-S**, **--session**=_SESSION_FILE_:
+
+    The policy session file generated via the **-S** option to
+    **tpm2_startauthsession**(1).
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+[supported hash algorithms](common/hash.md)
+
+[algorithm specifiers](common/alg.md)
+
+# EXAMPLES
+
+Starts a *trial* session, builds a PCR policy and uses that policy in the creation of an object.
+Then, it uses a *policy* session to unseal some data stored in the object.
+```
+# Step 1: Create a trial session and build a PCR policy via a policyPCR event to generate
+#   a policy hash.
+#
+# Step 2: Create an object and use the policy hash as the policy to satisfy for usage.
+#
+# Step 3: Create an actual policy session and using a policyPCR event, update the session
+#  policy hash.
+#
+# Step 4: Using the actual policy session from step 3 in tpm2_unseal to unseal the object.
+#
+
+tpm2_createprimary -H e -g sha256 -G ecc -C primary.ctx
+
+tpm2_pcrlist -Q -L "sha1:0,1,2,3 -o pcr.dat
+
+handle=`tpm2_startauthsession -S session.dat | cut -d' ' -f 2-2`
+
+tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -f policy.dat
+
+tpm2_flushcontext -H "$handle"
+
+tpm2_create -Q -g sha256 -G keyedhash -u key.pub -r key.priv -c primary.ctx -L policy.dat \
+  -A 'sign|fixedtpm|fixedparent|sensitivedataorigin' -I- <<< "12345678"
+
+tpm2_load -Q -c primary.ctx -u key.pub -r key.priv -n unseal.key.name -C unseal.key.ctx
+
+# Now that an object is created and a policy is required to access it, satisy the policy on
+# a session and use it to unseal the data stored in the object.
+
+handle=`tpm2_startauthsession -a -S session.dat | cut -d' ' -f 2-2`
+
+tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -f policy.dat
+
+unsealed=`tpm2_unseal -S session.dat -c unseal.key.ctx`
+
+echo "$unsealed"
+
+tpm2_flushcontext -H "$handle"
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tpm2_policyrestart.1.md
+++ b/man/tpm2_policyrestart.1.md
@@ -1,0 +1,60 @@
+% tpm2_policyrestart(1) tpm2-tools | General Commands Manual
+%
+% JANUARY 2018
+
+# NAME
+
+**tpm2_policyrestart**(1) - Restart an existing session with the TPM.
+
+# SYNOPSIS
+
+**tpm2_policyrestart** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tpm2_policyrestart**(1) Restarts a session with the TPM back to it's
+initial state. This is useful when the TPM gives one a TPM_RC_PCR_CHANGED
+(0x00000128) error code when using a PCR policy session. This will be returned
+if a PCR state affecting policy is altered during the session. One could restart
+the session and try again, however, the PCR state would still need to satisfy
+the policy
+
+# OPTIONS
+
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option. This session
+    is used in lieu of starting a session and using the PCR policy options. **-L** is
+    mutually exclusive of this option.
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+# EXAMPLES
+
+Start a *policy* session and restart it, unsealing some data.
+
+```
+tpm2_startauthsession -S session.dat -a
+
+tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -f policy.dat
+
+# pcr event occurs here casuiing unseal to fail
+tpm2_unseal -S session.dat -c unseal.key.ctx
+"Sys_Unseal failed. Error Code: 0x00000128"
+
+# restart the session, try again, pcr state must satisfy policy
+tpm2_sessionrestart -S session.dat
+
+tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -f policy.dat
+
+tpm2_unseal -S session.dat -c unseal.key.ctx
+
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -58,8 +58,9 @@
     Data given as a Hex string to qualify the  quote, optional. This is typically
     used to add a nonce against replay attacks.
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
-    Optional Input session handle from a policy session for authorization.
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
   * **-G**, **--sig-hash-algorithm**:
 

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -43,9 +43,9 @@ The key referenced by keyHandle is **required** to be:
 
     Output file path, record the decrypted data.
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
+  * **-S**, **--session**=_SESSION\_FILE_:
 
-    Optional Input session handle from a policy session for authorization.
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
 [common options](common/options.md)
 

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -42,10 +42,6 @@ The key referenced by keyHandle is **required** to be:
     xxd compatible hexdump to stdout. If a file is specified, raw binary
     output is performed.
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
-
-    Optional Input session handle from a policy session for authorization.
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -67,9 +67,9 @@ data and validation shall indicate that hashed data did not start with
 
     Format selection for the signature output file. See section "Signature Format Specifiers".
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
+  * **-S**, **--session**=_SESSION\_FILE_:
 
-    Optional Input session handle from a policy session for authorization.
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
 [common options](common/options.md)
 

--- a/man/tpm2_startauthsession.1.md
+++ b/man/tpm2_startauthsession.1.md
@@ -1,0 +1,71 @@
+% tpm2_startauthsession(1) tpm2-tools | General Commands Manual
+%
+% JANUARY 2018
+
+# NAME
+
+**tpm2_startauthsession**(1) - Start a session with the TPM.
+
+# SYNOPSIS
+
+**tpm2_startauthsession** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tpm2_startauthsession**(1) Starts a session with the TPM. The default is
+to start a *trial* session unless the **-a** option is specified. It outputs
+the session handle in a yaml format to stdout as key value "session-handle"
+and the handle in hex (0x1234) format.
+
+# OPTIONS
+
+  * **-a**, **--auth-policy-session**:
+
+    Change the policy session from a *trial* session to a *policy* session.
+    **NOTE**: A *trial* session is used when building a policy and a *policy*
+    session is used when authenticating with a policy.
+
+  * **-g**, **--policy-digest-alg**=_HASH\_ALGORITHM_:
+
+    The hash algorithm used in computation of the policy digest. Algorithms
+    should follow the "formatting standards", see section "Algorithm Specifiers".
+    Also, see section "Supported Hash Algorithms" for a list of supported hash
+    algorithms.
+
+  * **-S**, **--session**=_SESSION_FILE_:
+
+    Saves the policy session data to a file. This file can then be used in subsequent
+    tools that can use a policy file for authorization or policy events. **NOTE**: That
+    this will not work with resource managers (RMs) outside of tpm2-abrmd, as most RMs will
+    flush session handles when a client disconnects from the IPC channel. This will work
+    with direct TPM access, but note that internally this calls a *ContextSave* and a
+    *ContextLoad* on the session handle, thus the session **cannot** be saved/loaded
+    again.
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+[supported hash algorithms](common/hash.md)
+
+[algorithm specifiers](common/alg.md)
+
+# EXAMPLES
+
+Start a *trial* session and save the session data to a file.
+```
+tpm2_startauthsession -S session.dat
+session-handle: 0x3000000
+```
+
+Start a *policy* session and save the session data to a file.
+```
+tpm2_startauthsession -S session.dat -a
+session-handle: 0x3000000
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -38,15 +38,22 @@ alive and pass that session using the **--input-session-handle** option.
 
     Output file name, containing the unsealed data. Defaults to stdout if not specified.
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
+## Session Options
 
-    Optional Input session handle from a policy session for authorization.
+  Options used for controlling sessions and policy events.
+
+  * **-S**, **--session**=_SESSION\_FILE_:
+
+    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option. This session
+    is used in lieu of starting a session and using the PCR policy options. **-L** is
+    mutually exclusive of this option.
 
   * **-L**, **--set-list**==_PCR\_SELECTION\_LIST_:
 
     The list of pcr banks and selected PCRs' ids.
     _PCR\_SELECTION\_LIST_ values should follow the
     pcr bank specifiers standards, see section "PCR Bank Specfiers".
+    **-S** is mutually exclusive of this option.
 
   * **-F**,**--pcr-input-file=_PCR\_INPUT\_FILE_
 

--- a/test/system/tests/disabled/import.sh
+++ b/test/system/tests/disabled/import.sh
@@ -38,7 +38,7 @@ onerror() {
 trap onerror ERR
 
 cleanup() {
-    tpm2_evictcontrol -Q -A o -H 0x81010005 -S 0x81010005 2>/dev/null
+    tpm2_evictcontrol -Q -A o -H 0x81010005 -p 0x81010005 2>/dev/null
     rm -f import_key.ctx  import_key.name  import_key.priv  import_key.pub \
           parent.ctx parent.pub  plain.dec.ssl  plain.enc  plain.txt  sym.key
 }
@@ -47,7 +47,7 @@ trap cleanup EXIT
 cleanup
 
 tpm2_createprimary -Q -G 1 -g 0xb -H o -C parent.ctx
-tpm2_evictcontrol -Q -A o -c parent.ctx -S 0x81010005
+tpm2_evictcontrol -Q -A o -c parent.ctx -p 0x81010005
 
 dd if=/dev/urandom of=sym.key bs=1 count=16 2>/dev/null
 

--- a/test/system/tests/evictcontrol.sh
+++ b/test/system/tests/evictcontrol.sh
@@ -53,8 +53,8 @@ tpm2_create -Q -g sha256 -G keyedhash -u key.pub -r key.priv  -c primary.ctx
 
 tpm2_load -Q -c primary.ctx  -u key.pub  -r key.priv -n key.name -C key.ctx
 
-tpm2_evictcontrol -Q -A o -c key.ctx  -S 0x81010003
+tpm2_evictcontrol -Q -A o -c key.ctx -p 0x81010003
 
-tpm2_evictcontrol -Q -A o -H 0x81010003   -S 0x81010003
+tpm2_evictcontrol -Q -A o -H 0x81010003 -p 0x81010003
 
 exit 0

--- a/test/system/tests/flushcontext.sh
+++ b/test/system/tests/flushcontext.sh
@@ -61,10 +61,6 @@ tpm2_flushcontext -Q -t
 tpm2_createpolicy -Q -a -P -L sha256:0
 tpm2_flushcontext -Q -l
 
-# Test for flushing a saved session
-tpm2_createpolicy -Q -a -P -L sha256:0 -S saved_session.ctx
-tpm2_flushcontext -Q -s
-
 cleanup
 
 exit 0

--- a/test/system/tests/hmac.sh
+++ b/test/system/tests/hmac.sh
@@ -89,7 +89,7 @@ tpm2_hmac -Q -c $file_hmac_key_ctx -g $halg -o $file_hmac_output $file_input_dat
 ####handle test
 rm -f $file_hmac_output  
 
-tpm2_evictcontrol -A o -c $file_hmac_key_ctx -S $handle_hmac_key > evict.log
+tpm2_evictcontrol -A o -c $file_hmac_key_ctx -p $handle_hmac_key > evict.log
 grep -q "persistentHandle: "$handle_hmac_key"" evict.log
 
 echo "12345678" > $file_input_data

--- a/test/system/tests/listpersistent.sh
+++ b/test/system/tests/listpersistent.sh
@@ -41,7 +41,7 @@ cleanup() {
     for idx in "${!keys[@]}"
     do
         handle=$(printf "0x%X\n" $(($handle_base + $idx)))
-        tpm2_evictcontrol -Q -A "$auth" -H "$handle" -S "$handle"
+        tpm2_evictcontrol -Q -A "$auth" -H "$handle" -p "$handle"
     done
 
     rm -f primary.context
@@ -62,7 +62,7 @@ for idx in "${!keys[@]}"
 do
     tpm2_createprimary -Q -H "$auth" -g "${hashes[$idx]}" -G "${keys[$idx]}" -C primary.context
     handle=$(printf "0x%X\n" $(($handle_base + $idx)))
-    tpm2_evictcontrol -Q -A "$auth" -S "$handle" -c primary.context
+    tpm2_evictcontrol -Q -A "$auth" -p "$handle" -c primary.context
 done
 
 handle_cnt=$(tpm2_listpersistent | wc -l)

--- a/test/system/tests/load.sh
+++ b/test/system/tests/load.sh
@@ -80,7 +80,7 @@ tpm2_load -Q -c $file_primary_key_ctx  -u $file_load_key_pub  -r $file_load_key_
 
 cleanup keep_ctx
 
-tpm2_evictcontrol -Q -A o -c $file_primary_key_ctx  -S $Handle_parent
+tpm2_evictcontrol -Q -A o -c $file_primary_key_ctx -p $Handle_parent
 
 tpm2_create -Q -H $Handle_parent   -g $alg_create_obj  -G $alg_create_key -u $file_load_key_pub  -r  $file_load_key_priv
 

--- a/test/system/tests/loadexternal.sh
+++ b/test/system/tests/loadexternal.sh
@@ -71,7 +71,7 @@ tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_loadexternal_key_p
 
 tpm2_loadexternal -Q -H n   -u $file_loadexternal_key_pub   -C $file_loadexternal_key_ctx
 
-tpm2_evictcontrol -Q -A o -c $file_primary_key_ctx  -S $Handle_parent
+tpm2_evictcontrol -Q -A o -c $file_primary_key_ctx -p $Handle_parent
 
 # Test with Handle
 cleanup keep_handle

--- a/test/system/tests/quote.sh
+++ b/test/system/tests/quote.sh
@@ -91,7 +91,7 @@ tpm2_quote -Q -c $file_quote_key_ctx  -g $alg_quote -l 16,17,18 -q $nonce
 tpm2_quote -Q -c $file_quote_key_ctx  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce
 
 #####handle testing
-tpm2_evictcontrol -Q -A o -c $file_quote_key_ctx -S $Handle_ak_quote
+tpm2_evictcontrol -Q -A o -c $file_quote_key_ctx -p $Handle_ak_quote
 
 tpm2_quote -Q -k $Handle_ak_quote  -g $alg_quote -l 16,17,18 -q $nonce
 

--- a/test/system/tests/readpublic.sh
+++ b/test/system/tests/readpublic.sh
@@ -70,7 +70,7 @@ tpm2_load -Q -c $file_primary_key_ctx  -u $file_readpub_key_pub  -r $file_readpu
 
 tpm2_readpublic -Q -c $file_readpub_key_ctx -o $file_readpub_output
 
-tpm2_evictcontrol -Q -A o -c $file_readpub_key_ctx -S $Handle_readpub
+tpm2_evictcontrol -Q -A o -c $file_readpub_key_ctx -p $Handle_readpub
 
 rm -f $file_readpub_output
 tpm2_readpublic -Q -H $Handle_readpub -o $file_readpub_output

--- a/test/system/tests/sign.sh
+++ b/test/system/tests/sign.sh
@@ -80,7 +80,7 @@ tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_
 
 rm -f $file_output_data
 
-tpm2_evictcontrol -Q -A o -c $file_signing_key_ctx -S $handle_signing_key
+tpm2_evictcontrol -Q -A o -c $file_signing_key_ctx -p $handle_signing_key
 
 tpm2_sign -Q -k $handle_signing_key -g $alg_hash -m $file_input_data -s $file_output_data
 

--- a/test/system/tests/tcti/abrmd/extended-sessions.sh
+++ b/test/system/tests/tcti/abrmd/extended-sessions.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+#;**********************************************************************;
+#
+# Copyright (c) 2018, Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+alg_primary_obj=sha256
+alg_primary_key=ecc
+alg_create_obj=sha256
+alg_create_key=keyedhash
+alg_pcr_policy=sha1
+
+pcr_ids="0,1,2,3"
+
+file_pcr_value=pcr.bin
+file_input_data=secret.data
+file_policy=policy.data
+file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"
+file_unseal_key_pub=opu_"$alg_create_obj"_"$alg_create_key"
+file_unseal_key_priv=opr_"$alg_create_obj"_"$alg_create_key"
+file_unseal_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
+file_unseal_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
+file_unseal_output_data=usl_"$file_unseal_key_ctx"
+file_session_file="session.dat"
+
+secret="12345678"
+
+onerror() {
+    echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
+    exit 1
+}
+trap onerror ERR
+
+handle=""
+
+cleanup() {
+  rm -f $file_input_data $file_primary_key_ctx $file_unseal_key_pub \
+        $file_unseal_key_priv $file_unseal_key_ctx $file_unseal_key_name \
+        $file_unseal_output_data $file_pcr_value \
+        $file_policy $file_session_file
+
+  if [ -n "$handle" ]; then
+    tpm2_flushcontext -H "$handle" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+cleanup
+
+echo $secret > $file_input_data
+
+tpm2_clear
+
+#
+# Test an extended policy session beyond client connections. This is ONLY supported by abrmd
+# since version: https://github.com/intel/tpm2-abrmd/releases/tag/1.2.0
+# However, bug: https://github.com/intel/tpm2-abrmd/issues/285 applies
+#
+# The test works by:
+# Step 1: Creating a trial session and updating it with a policyPCR event to generate
+#   a policy hash.
+#
+# Step 2: Creating an object and using that policy hash as the policy to satisfy for usage.
+#
+# Step 3: Creating an actual policy session and using pcrpolicy event to update the policy.
+#
+# Step 4: Using that actual policy session from step 3 in tpm2_unseal to unseal the object.
+#
+
+tpm2_createprimary -Q -H e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
+
+tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+
+handle=`tpm2_startauthsession -S $file_session_file | cut -d' ' -f 2-2`
+
+tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
+
+tpm2_flushcontext -H "$handle"
+handle=""
+
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -c $file_primary_key_ctx -L $file_policy \
+  -A 'sign|fixedtpm|fixedparent|sensitivedataorigin' <<< $secret
+
+tpm2_load -Q -c $file_primary_key_ctx -u $file_unseal_key_pub -r $file_unseal_key_priv -n $file_unseal_key_name -C $file_unseal_key_ctx
+
+# Start a REAL policy session (-a option) and perform a pcr policy event
+handle=`tpm2_startauthsession -a -S $file_session_file | cut -d' ' -f 2-2`
+
+tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
+
+unsealed=`tpm2_unseal -S $file_session_file -c $file_unseal_key_ctx`
+
+test "$unsealed" == "$secret"
+
+exit 0

--- a/test/system/tests/tcti/abrmd/extended-sessions.sh
+++ b/test/system/tests/tcti/abrmd/extended-sessions.sh
@@ -118,4 +118,20 @@ unsealed=`tpm2_unseal -S $file_session_file -c $file_unseal_key_ctx`
 
 test "$unsealed" == "$secret"
 
+# Test resetting the policy session causes unseal to fail.
+tpm2_policyrestart -S $file_session_file
+
+# negative test, clear the error handler
+trap - ERR
+
+tpm2_unseal -S $file_session_file -c $file_unseal_key_ctx 2>/dev/null
+rc=$?
+
+# restore the error handler
+trap onerror ERR
+if [ $rc -eq 0 ]; then
+  echo "Expected tpm2_unseal to fail after policy reset"
+  false
+fi
+
 exit 0

--- a/test/unit/test_tpm2_session.c
+++ b/test/unit/test_tpm2_session.c
@@ -199,7 +199,7 @@ static void test_tpm2_session_defaults_good(void **state) {
     tpm2_session *s = tpm2_session_new(SAPI_CONTEXT, d);
     assert_non_null(s);
 
-    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(s);
+    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_handle(s);
     assert_int_equal(handle, SESSION_HANDLE);
 
     TPMI_ALG_HASH auth_hash = tpm2_session_get_authhash(s);
@@ -261,7 +261,7 @@ static void test_tpm2_session_setters_good(void **state) {
     tpm2_session *s = tpm2_session_new(SAPI_CONTEXT, d);
     assert_non_null(s);
 
-    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(s);
+    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_handle(s);
     assert_int_equal(handle, SESSION_HANDLE);
 
     TPMI_ALG_HASH auth_hash = tpm2_session_get_authhash(s);
@@ -305,7 +305,7 @@ static void test_tpm2_session_save(void **state) {
     tpm2_session *s = tpm2_session_new(SAPI_CONTEXT, d);
     assert_non_null(s);
 
-    TPMI_SH_AUTH_SESSION handle1 = tpm2_session_get_session_handle(s);
+    TPMI_SH_AUTH_SESSION handle1 = tpm2_session_get_handle(s);
 
     bool result = tpm2_session_save(SAPI_CONTEXT, s, (char *)*state);
     assert_true(result);
@@ -316,7 +316,7 @@ static void test_tpm2_session_save(void **state) {
     s = tpm2_session_restore((char *)*state);
     assert_non_null(s);
 
-    TPMI_SH_AUTH_SESSION handle2 = tpm2_session_get_session_handle(s);
+    TPMI_SH_AUTH_SESSION handle2 = tpm2_session_get_handle(s);
 
     assert_int_equal(handle1, handle2);
 

--- a/test/unit/test_tpm2_session.c
+++ b/test/unit/test_tpm2_session.c
@@ -215,6 +215,7 @@ static void test_tpm2_session_setters_good(void **state) {
     tpm2_session_data *d = tpm2_session_data_new(TPM2_SE_TRIAL);
     assert_non_null(d);
 
+
     tpm2_session_set_authhash(d, TPM2_ALG_SHA512);
 
     TPMT_SYM_DEF symmetric = {
@@ -346,6 +347,26 @@ static void test_tpm2_session_restart(void **state) {
     assert_null(s);
 }
 
+static void test_tpm2_session_is_trial_test(void **state) {
+    UNUSED(state);
+
+    set_expected_defaults(TPM2_SE_TRIAL, SESSION_HANDLE, TPM2_RC_SUCCESS);
+
+    tpm2_session_data *d = tpm2_session_data_new(TPM2_SE_TRIAL);
+    assert_non_null(d);
+
+    tpm2_session *s = tpm2_session_new(SAPI_CONTEXT, d);
+    assert_non_null(s);
+
+    TPM2_SE type = tpm2_session_get_type(s);
+    assert_int_equal(type, TPM2_SE_TRIAL);
+
+    bool is_trial = tpm2_session_is_trial(s);
+    assert_true(is_trial);
+
+    tpm2_session_free(&s);
+}
+
 /* link required symbol, but tpm2_tool.c declares it AND main, which
  * we have a main below for cmocka tests.
  */
@@ -368,6 +389,7 @@ int main(int argc, char *argv[]) {
     cmocka_unit_test_setup_teardown(test_tpm2_session_save,
             test_session_setup, test_session_teardown),
     cmocka_unit_test(test_tpm2_session_restart),
+    cmocka_unit_test(test_tpm2_session_is_trial_test)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -309,7 +309,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if (ctx.file.context) {
-        bool res = files_load_tpm_context_from_file(sapi_context, &ctx.handle.activate,
+        bool res = files_load_tpm_context_from_path(sapi_context, &ctx.handle.activate,
                 ctx.file.context);
         if (!res) {
             return 1;
@@ -317,7 +317,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if (ctx.file.key_context) {
-        bool res = files_load_tpm_context_from_file(sapi_context, &ctx.handle.key,
+        bool res = files_load_tpm_context_from_path(sapi_context, &ctx.handle.key,
                 ctx.file.key_context) != true;
         if (!res) {
             return 1;

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -181,7 +181,7 @@ static bool activate_credential_and_output(TSS2_SYS_CONTEXT *sapi_context) {
         return false;
     }
 
-    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(session);
+    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_handle(session);
 
 
     TPM2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_PolicySecret(sapi_context, TPM2_RH_ENDORSEMENT,

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -305,7 +305,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     /* Load input files */
     if (ctx.flags.C) {
-        result = files_load_tpm_context_from_file(sapi_context, &ctx.handle.obj,
+        result = files_load_tpm_context_from_path(sapi_context, &ctx.handle.obj,
                                                   ctx.context_file);
         if (!result) {
             return 1;
@@ -313,7 +313,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if (ctx.flags.c) {
-        result = files_load_tpm_context_from_file(sapi_context, &ctx.handle.key,
+        result = files_load_tpm_context_from_path(sapi_context, &ctx.handle.key,
                                                   ctx.context_key_file);
         if (!result) {
             return 1;

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -375,7 +375,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     } else if(flagCnt == 3 && (ctx.flags.H == 1 || ctx.flags.c == 1) &&
               ctx.flags.g == 1 && ctx.flags.G == 1) {
         if(ctx.flags.c)
-            returnVal = files_load_tpm_context_from_file(sapi_context,
+            returnVal = files_load_tpm_context_from_path(sapi_context,
                                                          &ctx.parent_handle, ctx.context_parent_path) != true;
         if(returnVal == 0)
             returnVal = create(sapi_context);

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -227,7 +227,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     if (pctx.common_policy_options.extend_policy_session) {
 
-        TPM2_HANDLE handle = tpm2_session_get_session_handle(pctx.common_policy_options.policy_session);
+        TPM2_HANDLE handle = tpm2_session_get_handle(pctx.common_policy_options.policy_session);
 
         LOG_INFO("EXTENDED_POLICY_SESSION_HANDLE: 0x%08X\n", handle);
 

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -234,7 +234,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         const char *file = pctx.common_policy_options.context_file;
 
         if (file) {
-            return files_save_tpm_context_to_file(sapi_context,
+            return files_save_tpm_context_to_path(sapi_context,
                                                   handle, file) != true;
         }
     }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -47,6 +47,7 @@
 #include "tpm2_attr_util.h"
 #include "tpm2_options.h"
 #include "tpm2_password_util.h"
+#include "tpm2_session.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 
@@ -281,13 +282,15 @@ static bool on_option(char key, char *value) {
             return false;
         }
     } break;
-    case 'S':
-        if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
-            LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                    value);
+    case 'S': {
+        tpm2_session *s = tpm2_session_restore(value);
+        if (!s) {
             return false;
         }
-        break;
+
+        ctx.session_data.sessionHandle = tpm2_session_get_handle(s);
+        tpm2_session_free(&s);
+    } break;
     }
 
     return true;

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -325,7 +325,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         returnVal = create_primary(sapi_context);
 
         if (returnVal == 0 && ctx.flags.C) {
-            returnVal = files_save_tpm_context_to_file(sapi_context, ctx.handle2048rsa,
+            returnVal = files_save_tpm_context_to_path(sapi_context, ctx.handle2048rsa,
                                                        ctx.context_file) != true;
         }
 

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -36,9 +36,10 @@
 
 #include <sapi/tpm20.h>
 
+#include "log.h"
 #include "tpm2_options.h"
 #include "tpm2_password_util.h"
-#include "log.h"
+#include "tpm2_session.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 
@@ -142,13 +143,15 @@ static bool on_option(char key, char *value) {
             return false;
         }
         break;
-    case 'S':
-        if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
-            LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                    value);
+    case 'S': {
+        tpm2_session *s = tpm2_session_restore(value);
+        if (!s) {
             return false;
         }
-        break;
+
+        ctx.session_data.sessionHandle = tpm2_session_get_handle(s);
+        tpm2_session_free(&s);
+    } break;
     }
 
     return true;

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -200,7 +200,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if (ctx.flags.c) {
-        result = files_load_tpm_context_from_file(sapi_context, &ctx.key_handle,
+        result = files_load_tpm_context_from_path(sapi_context, &ctx.key_handle,
                                                   ctx.context_key_file);
         if (!result) {
             return 1;

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -40,11 +40,12 @@
 
 #include <sapi/tpm20.h>
 
-#include "tpm2_options.h"
-#include "tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
+#include "tpm2_options.h"
+#include "tpm2_password_util.h"
 #include "tpm2_tool.h"
+#include "tpm2_session.h"
 #include "tpm2_util.h"
 
 typedef struct tpm_evictcontrol_ctx tpm_evictcontrol_ctx;
@@ -135,7 +136,7 @@ static bool on_option(char key, char *value) {
             ctx.flags.S = 1;
         }
         break;
-    case 'S':
+    case 'p':
         result = tpm2_util_string_to_uint32(value, &ctx.handle.persist);
         if (!result) {
             LOG_ERR("Could not convert persistent handle to a number, got: \"%s\"",
@@ -156,7 +157,7 @@ static bool on_option(char key, char *value) {
         ctx.context_file = value;
         ctx.flags.c = 1;
         break;
-    case 'i':
+    case 'S':
         if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
             LOG_ERR("Could not convert session handle to number, got: \"%s\"",
                     value);
@@ -173,15 +174,15 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     const struct option topts[] = {
       { "auth",                 required_argument, NULL, 'A' },
       { "handle",               required_argument, NULL, 'H' },
-      { "persistent",           required_argument, NULL, 'S' },
+      { "persistent",           required_argument, NULL, 'p' },
       { "pwda",                 required_argument, NULL, 'P' },
       { "context",              required_argument, NULL, 'c' },
-      { "input-session-handle", required_argument, NULL, 'i' },
+      { "session",              required_argument, NULL, 'S' },
     };
 
     ctx.session_data.sessionHandle = TPM2_RS_PW;
 
-    *opts = tpm2_options_new("A:H:S:P:c:i:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("A:H:p:P:c:S:", ARRAY_LEN(topts), topts, on_option,
                              NULL, true);
 
     return *opts != NULL;

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -197,7 +197,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if (ctx.flags.c) {
-        bool result = files_load_tpm_context_from_file(sapi_context, &ctx.handle.object,
+        bool result = files_load_tpm_context_from_path(sapi_context, &ctx.handle.object,
                                                        ctx.context_file);
         if (!result) {
             return 1;

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -35,14 +35,18 @@
 
 #include "log.h"
 #include "tpm2_options.h"
+#include "tpm2_session.h"
 #include "tpm2_util.h"
 
 struct tpm_flush_context_ctx {
     UINT32 property;
     TPM2_HANDLE objectHandle;
+    struct {
+        char *path;
+    } session;
 };
 
-static struct tpm_flush_context_ctx ctx = { .property = -1, };
+static struct tpm_flush_context_ctx ctx;
 
 static const char *get_property_name(TPM2_HANDLE handle) {
 
@@ -109,7 +113,6 @@ static bool on_option(char key, char *value) {
         if (!result) {
             return false;
         }
-        ctx.property = 0;
         break;
     case 't':
         ctx.property = TPM2_TRANSIENT_FIRST;
@@ -120,6 +123,9 @@ static bool on_option(char key, char *value) {
     case 's':
         ctx.property = TPM2_ACTIVE_SESSION_FIRST;
         break;
+    case 'S':
+        ctx.session.path = value;
+    break;
     }
 
     return true;
@@ -128,13 +134,14 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-        { "handle",           no_argument, NULL, 'H' },
-        { "transient-object", no_argument, NULL, 't' },
-        { "loaded-session",   no_argument, NULL, 'l' },
-        { "saved-session",    no_argument, NULL, 's' },
+        { "handle",           no_argument,        NULL, 'H' },
+        { "transient-object", no_argument,        NULL, 't' },
+        { "loaded-session",   no_argument,        NULL, 'l' },
+        { "saved-session",    no_argument,        NULL, 's' },
+        { "session",          required_argument,  NULL, 'S' },
     };
 
-    *opts = tpm2_options_new("H:tls", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("H:tlsS:", ARRAY_LEN(topts), topts,
                              on_option, NULL, true);
 
     return *opts != NULL;
@@ -143,11 +150,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     UNUSED(flags);
-
-    if (ctx.property == (UINT32)-1) {
-        LOG_ERR("Expected options H, t, l or s");
-        return 1;
-    }
 
     TPMS_CAPABILITY_DATA capability_data = TPMS_CAPABILITY_DATA_EMPTY_INIT;
     TPML_HANDLE *handles = &capability_data.data.handles;
@@ -160,6 +162,19 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
             return 1;
         }
     } else {
+
+        /* handle from a session file */
+        if (ctx.session.path) {
+            tpm2_session *s = tpm2_session_restore(ctx.session.path);
+            if (!s) {
+                return 1;
+            }
+
+            ctx.objectHandle = tpm2_session_get_session_handle(s);
+
+            tpm2_session_free(&s);
+        }
+
         handles->handle[0] = ctx.objectHandle;
         handles->count = 1;
     }

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -170,7 +170,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
                 return 1;
             }
 
-            ctx.objectHandle = tpm2_session_get_session_handle(s);
+            ctx.objectHandle = tpm2_session_get_handle(s);
 
             tpm2_session_free(&s);
         }

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -253,7 +253,7 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
 
     LOG_INFO("tpm_session_start_auth_with_params succ");
 
-    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(session);
+    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_handle(session);
     tpm2_session_free(&session);
 
 
@@ -317,7 +317,7 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
 
     LOG_INFO("tpm_session_start_auth_with_params succ");
 
-    handle = tpm2_session_get_session_handle(session);
+    handle = tpm2_session_get_handle(session);
     tpm2_session_free(&session);
 
     rval = TSS2_RETRY_EXP(Tss2_Sys_PolicySecret(sapi_context, TPM2_RH_ENDORSEMENT,

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -304,7 +304,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if (ctx.flags.c) {
-        result = files_load_tpm_context_from_file(sapi_context, &ctx.key_handle,
+        result = files_load_tpm_context_from_path(sapi_context, &ctx.key_handle,
                                                   ctx.context_key_file_path);
         if (!result) {
             LOG_ERR("Loading tpm context from file \"%s\" failed.",

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -207,7 +207,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if(ctx.flags.c) {
-        returnVal = files_load_tpm_context_from_file(sapi_context,
+        returnVal = files_load_tpm_context_from_path(sapi_context,
                                                &ctx.parent_handle,
                                                ctx.context_parent_file) != true;
         if (returnVal) {
@@ -221,7 +221,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if (ctx.flags.C) {
-        returnVal = files_save_tpm_context_to_file (sapi_context,
+        returnVal = files_save_tpm_context_to_path (sapi_context,
                                                     handle2048rsa,
                                                     ctx.context_file) != true;
         if (returnVal) {

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -171,7 +171,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if(ctx.save_to_context_file) {
-            return files_save_tpm_context_to_file(sapi_context, ctx.rsa2048_handle,
+            return files_save_tpm_context_to_path(sapi_context, ctx.rsa2048_handle,
                     ctx.context_file_path) != true;
     }
 

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -288,7 +288,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
             return 1;
         }
 
-        ctx.session_data.sessionHandle = tpm2_session_get_session_handle(ctx.policy_session);
+        ctx.session_data.sessionHandle = tpm2_session_get_handle(ctx.policy_session);
         ctx.session_data.sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
     }
 
@@ -297,7 +297,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     if (ctx.policy_session) {
 
-        TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(ctx.policy_session);
+        TPMI_SH_AUTH_SESSION handle = tpm2_session_get_handle(ctx.policy_session);
 
         TSS2_RC rval = Tss2_Sys_FlushContext(sapi_context,
                 handle);

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -277,7 +277,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
             return 1;
         }
 
-        ctx.session_data.sessionHandle = tpm2_session_get_session_handle(ctx.policy_session);
+        ctx.session_data.sessionHandle = tpm2_session_get_handle(ctx.policy_session);
         ctx.session_data.sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
     }
 
@@ -335,7 +335,7 @@ out:
 
     if (ctx.policy_session) {
 
-        TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(ctx.policy_session);
+        TPMI_SH_AUTH_SESSION handle = tpm2_session_get_handle(ctx.policy_session);
 
         TSS2_RC rval = Tss2_Sys_FlushContext(sapi_context,
                                             handle);

--- a/tools/tpm2_policypcr.c
+++ b/tools/tpm2_policypcr.c
@@ -1,0 +1,165 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+#include <ctype.h>
+
+#include <sapi/tpm20.h>
+
+#include "files.h"
+#include "log.h"
+#include "pcr.h"
+#include "tpm2_options.h"
+#include "tpm2_policy.h"
+#include "tpm2_session.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+
+typedef struct tpm2_startauthsession_ctx tpm2_startauthsession_ctx;
+struct tpm2_startauthsession_ctx {
+   const char *session_path;
+   const char *raw_pcrs_file;
+   TPML_PCR_SELECTION pcr_selection;
+   const char *policy_out_path;
+};
+
+static tpm2_startauthsession_ctx ctx;
+
+static bool on_option(char key, char *value) {
+
+    switch (key) {
+    case 'f':
+        ctx.policy_out_path = value;
+        break;
+    case 'F':
+        ctx.raw_pcrs_file = value;
+        break;
+    case 'L': {
+        bool result = pcr_parse_selections(value, &ctx.pcr_selection);
+        if (!result) {
+            LOG_ERR("Could not parse PCR selections");
+            return false;
+        }
+    } break;
+    case 'S':
+        ctx.session_path = value;
+    break;
+    }
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    static struct option topts[] = {
+        { "policy-file",    required_argument,  NULL,   'f' },
+        { "pcr-input-file", required_argument,  NULL,   'F' },
+        { "set-list",       required_argument,  NULL,   'L' },
+        { "session",        required_argument,  NULL,   'S' },
+    };
+
+    *opts = tpm2_options_new("f:F:L:S:", ARRAY_LEN(topts), topts, on_option,
+                             NULL, false);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    int rc = 1;
+    tpm2_session *s = NULL;
+
+    bool fail = false;
+    if (!ctx.session_path) {
+        LOG_ERR("Must specify -S session file");
+        fail = true;
+    }
+
+    if (!ctx.pcr_selection.count) {
+        LOG_ERR("Must specify -L pcr selection list");
+        fail = true;
+    }
+
+    if (fail) {
+        return rc;
+    }
+
+    s = tpm2_session_restore(ctx.session_path);
+    if (!s) {
+        return rc;
+    }
+
+
+    bool result = tpm2_policy_build_pcr(sapi_context, s,
+            ctx.raw_pcrs_file,
+            &ctx.pcr_selection);
+    if (!result) {
+        LOG_ERR("Could not build pcr policy");
+        goto out;
+    }
+
+    TPM2B_DIGEST policy_digest = TPM2B_EMPTY_INIT;
+    result = tpm2_policy_get_digest(sapi_context, s,
+            &policy_digest);
+    if (!result) {
+        LOG_ERR("Could not build tpm policy");
+        goto out;
+    }
+
+    tpm2_tool_output("policy_digest: 0x");
+    UINT16 i;
+    for(i = 0; i < policy_digest.size; i++) {
+        tpm2_tool_output("%02X", policy_digest.buffer[i]);
+    }
+    tpm2_tool_output("\n");
+
+    if (ctx.policy_out_path) {
+        result = files_save_bytes_to_file(ctx.policy_out_path,
+                    (UINT8 *) &policy_digest.buffer,
+                    policy_digest.size);
+        if (!result) {
+            LOG_ERR("Failed to save policy digest into file \"%s\"",
+                    ctx.policy_out_path);
+            goto out;
+        }
+    }
+
+    rc = 0;
+
+out:
+    tpm2_session_free(&s);
+    return rc;
+}

--- a/tools/tpm2_policyrestart.c
+++ b/tools/tpm2_policyrestart.c
@@ -1,0 +1,101 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+#include <ctype.h>
+
+#include <sapi/tpm20.h>
+
+#include "files.h"
+#include "log.h"
+#include "pcr.h"
+#include "tpm2_options.h"
+#include "tpm2_policy.h"
+#include "tpm2_session.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+
+typedef struct tpm2_policyreset_ctx tpm2_policyreset_ctx;
+struct tpm2_policyreset_ctx {
+   struct {
+       char *path;
+   } session;
+};
+
+static tpm2_policyreset_ctx ctx;
+
+static bool on_option(char key, char *value) {
+
+    switch (key) {
+    case 'S':
+        ctx.session.path = value;
+    break;
+    }
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    static struct option topts[] = {
+        { "session",        required_argument,  NULL,   'S' },
+    };
+
+    *opts = tpm2_options_new("S:", ARRAY_LEN(topts), topts, on_option,
+                             NULL, false);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    int rc = 1;
+    tpm2_session *s = tpm2_session_restore(ctx.session.path);
+    if (!s) {
+        return rc;
+    }
+
+    bool result = tpm2_session_restart(sapi_context, s);
+    if (!result) {
+        goto out;
+    }
+
+    rc = 0;
+
+out:
+    tpm2_session_free(&s);
+    return rc;
+}

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -259,7 +259,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if(c_flag) {
-        bool result = files_load_tpm_context_from_file(sapi_context, &akHandle, contextFilePath);
+        bool result = files_load_tpm_context_from_path(sapi_context, &akHandle, contextFilePath);
         if (!result) {
             return 1;
         }

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -149,7 +149,7 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
     }
 
     if (ctx.flags.c) {
-        bool result = files_load_tpm_context_from_file(sapi_context, &ctx.objectHandle,
+        bool result = files_load_tpm_context_from_path(sapi_context, &ctx.objectHandle,
                 ctx.context_file);
         if (!result) {
             return false;

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -35,10 +35,11 @@
 
 #include <sapi/tpm20.h>
 
-#include "tpm2_options.h"
-#include "tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
+#include "tpm2_options.h"
+#include "tpm2_password_util.h"
+#include "tpm2_session.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 
@@ -132,14 +133,15 @@ static bool on_option(char key, char *value) {
         ctx.context_key_file = value;
         ctx.flags.c = 1;
         break;
-    case 'S':
-         if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
-             LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                     value);
-             return false;
-         }
-         break;
-         /* no default */
+    case 'S': {
+        tpm2_session *s = tpm2_session_restore(value);
+        if (!s) {
+            return false;
+        }
+
+        ctx.session_data.sessionHandle = tpm2_session_get_handle(s);
+        tpm2_session_free(&s);
+    } break;
     }
 
     return true;
@@ -148,12 +150,12 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-      { "key-handle",           required_argument, NULL, 'k' },
-      { "pwdk",                 required_argument, NULL, 'P' },
-      { "in-file",              required_argument, NULL, 'I' },
-      { "out-file",             required_argument, NULL, 'o' },
-      { "key-context",          required_argument, NULL, 'c' },
-      { "input-session-handle", required_argument, NULL, 'S' },
+      { "key-handle",   required_argument, NULL, 'k' },
+      { "pwdk",         required_argument, NULL, 'P' },
+      { "in-file",      required_argument, NULL, 'I' },
+      { "out-file",     required_argument, NULL, 'o' },
+      { "key-context",  required_argument, NULL, 'c' },
+      { "session",      required_argument, NULL, 'S' },
     };
 
     *opts = tpm2_options_new("k:P:I:o:c:S:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -171,7 +171,7 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
     }
 
     if (ctx.flags.c) {
-        bool result = files_load_tpm_context_from_file(sapi_context,
+        bool result = files_load_tpm_context_from_path(sapi_context,
                 &ctx.key_handle, ctx.context_key_file);
         if (!result) {
             return false;

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -148,7 +148,7 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
     }
 
     if (ctx.flags.c) {
-        bool result = files_load_tpm_context_from_file(sapi_context, &ctx.key_handle,
+        bool result = files_load_tpm_context_from_path(sapi_context, &ctx.key_handle,
                 ctx.context_key_file);
         if (!result) {
             return false;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -135,7 +135,7 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
      * load tpm context from a file if -c is provided
      */
     if (ctx.flags.c) {
-        bool result = files_load_tpm_context_from_file(sapi_context, &ctx.keyHandle,
+        bool result = files_load_tpm_context_from_path(sapi_context, &ctx.keyHandle,
                 ctx.contextKeyFile);
         if (!result) {
             return false;

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -119,7 +119,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         return rc;
     }
 
-    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(s);
+    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_handle(s);
     tpm2_tool_output("session-handle: 0x%" PRIx32 "\n", handle);
 
     if (ctx.output.path) {

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -1,0 +1,138 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+#include <ctype.h>
+
+#include <sapi/tpm20.h>
+
+#include "files.h"
+#include "log.h"
+#include "tpm2_alg_util.h"
+#include "tpm2_options.h"
+#include "tpm2_session.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+
+typedef struct tpm2_startauthsession_ctx tpm2_startauthsession_ctx;
+struct tpm2_startauthsession_ctx {
+    struct {
+        TPM2_SE type;
+        TPMI_ALG_HASH halg;
+    } session;
+    struct {
+        const char *path;
+    } output;
+};
+
+static tpm2_startauthsession_ctx ctx = {
+    .session = {
+        .type = TPM2_SE_TRIAL,
+        .halg = TPM2_ALG_SHA256
+    }
+};
+
+static bool on_option(char key, char *value) {
+
+    switch (key) {
+    case 'a':
+        ctx.session.type = TPM2_SE_POLICY;
+        break;
+    case 'g':
+        ctx.session.halg = tpm2_alg_util_from_optarg(value);
+        if(ctx.session.halg == TPM2_ALG_ERROR) {
+            LOG_ERR("Invalid choice for policy digest hash algorithm");
+            return false;
+        }
+        break;
+    case 'S':
+        ctx.output.path = value;
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    static struct option topts[] = {
+        { "auth-policy-session", no_argument,       NULL, 'a'},
+        { "policy-digest-alg",   required_argument, NULL, 'g'},
+        { "session",             required_argument, NULL, 'S'},
+    };
+
+    *opts = tpm2_options_new("ag:S:", ARRAY_LEN(topts), topts, on_option,
+                             NULL, false);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    int rc = 1;
+    tpm2_session_data *session_data = tpm2_session_data_new(ctx.session.type);
+    if (!session_data) {
+        LOG_ERR("oom");
+        return rc;
+    }
+
+    tpm2_session_set_authhash(session_data, ctx.session.halg);
+
+    tpm2_session *s = tpm2_session_new(sapi_context,
+            session_data);
+    if (!s) {
+        return rc;
+    }
+
+    TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(s);
+    tpm2_tool_output("session-handle: 0x%" PRIx32 "\n", handle);
+
+    if (ctx.output.path) {
+        bool result = tpm2_session_save(sapi_context, s, ctx.output.path);
+        if (!result) {
+            goto out;
+        }
+    }
+
+    rc = 0;
+
+out:
+    tpm2_session_free(&s);
+
+    return rc;
+}

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -36,7 +36,6 @@
 
 #include <sapi/tpm20.h>
 
-#include "tpm2_session.h"
 #include "files.h"
 #include "log.h"
 #include "pcr.h"
@@ -44,6 +43,7 @@
 #include "tpm2_password_util.h"
 #include "tpm2_policy.h"
 #include "tpm2_tool.h"
+#include "tpm2_session.h"
 #include "tpm2_util.h"
 
 typedef struct tpm_unseal_ctx tpm_unseal_ctx;

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -152,7 +152,6 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
 
     if (ctx.policy_session) {
         ctx.sessionData.sessionHandle = tpm2_session_get_session_handle(ctx.policy_session);
-        ctx.sessionData.sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
     }
 
     return true;

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -151,7 +151,7 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
     }
 
     if (ctx.policy_session) {
-        ctx.sessionData.sessionHandle = tpm2_session_get_session_handle(ctx.policy_session);
+        ctx.sessionData.sessionHandle = tpm2_session_get_handle(ctx.policy_session);
     }
 
     return true;
@@ -242,7 +242,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
          * Only flush sessions started internally by the tool.
          */
         if (ctx.flags.S) {
-            TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(ctx.policy_session);
+            TPMI_SH_AUTH_SESSION handle = tpm2_session_get_handle(ctx.policy_session);
 
             TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context,
                                                 handle));

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -233,15 +233,19 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if (ctx.policy_session) {
-        TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(ctx.policy_session);
+        /*
+         * Only flush sessions started internally by the tool.
+         */
+        if (ctx.flags.S) {
+            TPMI_SH_AUTH_SESSION handle = tpm2_session_get_session_handle(ctx.policy_session);
 
-        TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context,
-                                            handle));
-        if (rval != TPM2_RC_SUCCESS) {
-            LOG_ERR("Failed Flush Context: 0x%x", rval);
-            return 1;
+            TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context,
+                                                handle));
+            if (rval != TPM2_RC_SUCCESS) {
+                LOG_ERR("Failed Flush Context: 0x%x", rval);
+                return 1;
+            }
         }
-
         tpm2_session_free(&ctx.policy_session);
     }
 

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -141,8 +141,14 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
         if (!ctx.policy_session) {
             return false;
         }
-    }
 
+        bool is_trial = tpm2_session_is_trial(ctx.policy_session);
+        if (is_trial) {
+            LOG_ERR("A trial session cannot be used to authenticate, "
+                    "Please use an hmac or policy session");
+            return false;
+        }
+    }
 
     if (ctx.policy_session) {
         ctx.sessionData.sessionHandle = tpm2_session_get_session_handle(ctx.policy_session);

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -98,7 +98,7 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
     }
 
     if (ctx.flags.c) {
-        bool result = files_load_tpm_context_from_file(sapi_context, &ctx.itemHandle,
+        bool result = files_load_tpm_context_from_path(sapi_context, &ctx.itemHandle,
                 ctx.contextItemFile);
         if (!result) {
             return false;

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -160,7 +160,7 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
     }
 
     if (ctx.flags.key_context) {
-        bool result = files_load_tpm_context_from_file(sapi_context, &ctx.keyHandle,
+        bool result = files_load_tpm_context_from_path(sapi_context, &ctx.keyHandle,
                 ctx.context_key_file_path);
         if (!result) {
             goto err;


### PR DESCRIPTION
This patchset leaves all the old session handling stuff pretty much in place, with the exception of the session option -S using a file to pass the data versus just a hex string argument. I found tools needing more information about a session, so rather than adding options, we just encode it in the file along with the handle.

Outside of that, it adds tpm2_startauthsession and tpm2_policypcr tools, which essentially breaks out the tpm2_createpolicy functionality into discrete tools.

I'm looking for early feedback before I go continuing down this path of adding more policy event tools and updating all the "-S" options currently. I am mostly interested in large architectural changes to the code they may need to occur versus a pedantic code review, but both are welcome/appreciated.
@martinezjavier 

I tested this against abrmd, with a known issue of: https://github.com/intel/tpm2-abrmd/issues/285