### PR TITLE
tools: avoid sapi init if tool doesn't need it

### DIFF
--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2016-2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,12 +41,19 @@
 
 typedef struct tpm2_options tpm2_options;
 
+#define tpm2_option_flags_init(x) { .all = x };
+
 typedef union tpm2_option_flags tpm2_option_flags;
 union tpm2_option_flags {
     struct {
+#define TPM2_OPTION_FLAG_VERBOSE       (1 << 0)
         UINT8 verbose : 1;
+#define TPM2_OPTION_FLAG_QUIET         (1 << 1)
         UINT8 quiet   : 1;
+#define TPM2_OPTION_FLAG_ENABLE_ERRATA (1 << 2)
         UINT8 enable_errata  : 1;
+#define TPM2_OPTION_NO_SAPI            (1 << 3)
+        UINT8 no_sapi : 1;
     };
     UINT8 all;
 };
@@ -112,12 +119,17 @@ typedef bool (*tpm2_arg_handler)(int argc, char **argv);
  * @param on_arg
  *  An argument handling callback, which may be null if you don't wish
  *  to handle arguments.
+ * @flags
+ *  Flags for changing behavior, notably TPM2_OPTION_NO_SAPI is
+ *  respected.
  * @return
  *  NULL on failure or an initialized tpm2_options object.
  */
 tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
         const struct option *long_opts, tpm2_option_handler on_opt,
-        tpm2_arg_handler on_arg);
+        tpm2_arg_handler on_arg, tpm2_option_flags flags);
+
+tpm2_option_flags *tpm2_options_get_flags(tpm2_options *opts);
 
 /**
  * Concatenates two tpm2_options objects, with src appended on

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -303,8 +303,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
          {"passwdInHex",   no_argument,       NULL, 'X'},
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("H:c:k:C:P:e:f:o:X", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -314,8 +314,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {NULL,           no_argument,       NULL, '\0'}
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("H:k:P:K:g:a:s:C:c:f:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -349,7 +349,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setbuf(stdout, NULL);
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
-    *opts = tpm2_options_new("H:P:K:g:G:A:I:L:u:r:c:S:", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("H:P:K:g:G:A:I:L:u:r:c:S:", ARRAY_LEN(topts),
+            topts, on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -197,7 +197,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "extend-policy-session", no_argument, NULL,   'e'},
     };
 
-    *opts = tpm2_options_new("f:g:L:F:Pae", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("f:g:L:F:Pae", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -323,7 +323,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setbuf(stdout, NULL);
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
-    *opts = tpm2_options_new("A:P:K:g:G:C:L:S:H:", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("A:P:K:g:G:C:L:S:H:", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -176,7 +176,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "input-session-handle",required_argument,NULL,'S'},
     };
 
-    *opts = tpm2_options_new("n:t:l:P:S:cs", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("n:t:l:P:S:cs", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -195,7 +195,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     ctx.session_data.sessionHandle = TPM_RS_PW;
 
-    *opts = tpm2_options_new("k:P:DI:o:c:S:", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("k:P:DI:o:c:S:", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -191,7 +191,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     ctx.session_data.sessionHandle = TPM_RS_PW;
 
-    *opts = tpm2_options_new("A:H:S:P:c:i:", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("A:H:S:P:c:i:", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2016-2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -842,7 +842,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "capability", required_argument, NULL, 'c' },
     };
 
-    *opts = tpm2_options_new("c:", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("c:", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -538,8 +538,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         {"input-session-handle",1,NULL,'S'},
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("e:o:H:P:g:f:NO:E:S:i:U", ARRAY_LEN(topts), topts,
-            on_option, on_args);
+            on_option, on_args, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -480,7 +480,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "ak-name"     , required_argument, NULL, 'n' },
     };
 
-    *opts = tpm2_options_new("o:E:e:k:g:D:s:P:f:n:p:", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("o:E:e:k:g:D:s:P:f:n:p:", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -315,7 +315,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "help"         , no_argument,       NULL, 'h' },
     };
 
-    *opts = tpm2_options_new("e:o:H:P:g:f:p:S:d:hv", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("e:o:H:P:g:f:p:S:d:hv", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -109,7 +109,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "output",   required_argument, NULL, 'o' },
     };
 
-    *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts, on_option, on_args);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts,
+            on_option, on_args, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -190,7 +190,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     /* set up non-static defaults here */
     ctx.input_file = stdin;
 
-    *opts = tpm2_options_new("H:g:o:t:", ARRAY_LEN(topts), topts, on_option, on_args);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("H:g:o:t:", ARRAY_LEN(topts), topts,
+            on_option, on_args, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -292,7 +292,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     ctx.input = stdin;
 
-    *opts = tpm2_options_new("k:P:g:o:S:c:", ARRAY_LEN(topts), topts, on_option, on_args);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("k:P:g:o:S:c:", ARRAY_LEN(topts), topts,
+            on_option, on_args, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2016, Intel Corporation
+// Copyright (c) 2016-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -142,7 +142,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         {"kalg", required_argument, NULL, 'G'},
     };
 
-    *opts = tpm2_options_new("g:G:", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("g:G:", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -199,7 +199,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setbuf(stdout, NULL);
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
-    *opts = tpm2_options_new("H:P:u:r:n:C:c:S:", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("H:P:u:r:n:C:c:S:", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -154,7 +154,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "context",  required_argument, NULL, 'C'},
     };
 
-    *opts = tpm2_options_new("H:u:r:C:", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("H:u:r:C:", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -217,7 +217,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {NULL      ,no_argument      , NULL, '\0'}
     };
 
-    *opts = tpm2_options_new("e:s:n:o:", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("e:s:n:o:", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -213,7 +213,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "input-session-handle",   required_argument,  NULL,   'S' },
     };
 
-    *opts = tpm2_options_new("x:a:s:t:P:I:rwdL:S:X", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("x:a:s:t:P:I:rwdL:S:X", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -265,8 +265,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         {"pcr-input-file", required_argument, NULL, 'F' },
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("x:a:f:s:o:P:S:L:F:", ARRAY_LEN(topts),
-            topts, on_option, NULL);
+            topts, on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // Copyright (c) 2016, Atom Software Studios
 // All rights reserved.
 //
@@ -148,7 +148,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "input-session-handle",1,          NULL, 'S' },
     };
 
-    *opts = tpm2_options_new("x:a:P:Xp:d:S:hv", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("x:a:P:Xp:d:S:hv", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -135,7 +135,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "input-session-handle",1,          NULL, 'S' },
     };
 
-    *opts = tpm2_options_new("x:a:s:o:P:S:", ARRAY_LEN(topts), topts, on_option, NULL);
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
+    *opts = tpm2_options_new("x:a:s:o:P:S:", ARRAY_LEN(topts), topts,
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -247,8 +247,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         {"pcr-input-file", required_argument, NULL, 'F' },
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("x:a:P:S:o:L:F:", ARRAY_LEN(topts), topts,
-            on_option, on_args);
+            on_option, on_args, empty_flags);
 
     ctx.input_file = stdin;
 

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -340,8 +340,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "password",             required_argument, NULL, 'P' },
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("i:S:P:", ARRAY_LEN(topts), topts,
-            on_option, on_arg);
+            on_option, on_arg, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
+// Copyright (c) 2017-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -120,8 +120,9 @@ static bool on_arg(int argc, char **argv) {
 
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new(NULL, 0, NULL,
-            NULL, on_arg);
+            NULL, on_arg, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -401,8 +401,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
          { "format",    required_argument, NULL, 'f' },
      };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("g:o:L:s", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -259,8 +259,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "sig-hash-algorithm",   required_argument, NULL, 'G' }
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("k:c:P:l:g:L:S:q:s:m:f:G:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_rc_decode.c
+++ b/tools/tpm2_rc_decode.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2016, Intel Corporation
+// Copyright (c) 2016-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -244,8 +244,9 @@ static bool on_arg(int argc, char **argv) {
 
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
+    tpm2_option_flags flags = tpm2_option_flags_init(TPM2_OPTION_NO_SAPI);
     *opts = tpm2_options_new(NULL, 0, NULL,
-            NULL, on_arg);
+            NULL, on_arg, flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -142,8 +142,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "format",        required_argument, NULL,'f' }
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("H:o:c:f:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -166,8 +166,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "input-session-handle",1,         NULL, 'S' },
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("k:P:I:o:c:S:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -140,8 +140,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {"key-context", required_argument, NULL, 'c'},
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("k:o:c:", ARRAY_LEN(topts), topts,
-            on_option, on_args);
+            on_option, on_args, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2016-2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -157,8 +157,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "--output", required_argument, NULL, 'o' },
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("i:o:", ARRAY_LEN(topts), topts,
-            on_option, on_args);
+            on_option, on_args, empty_flags);
 
     ctx.input = stdin;
     ctx.output = stdout;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -271,8 +271,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {"format",               required_argument, NULL, 'f'}
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("k:P:g:m:t:s:c:S:f:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_startup.c
+++ b/tools/tpm2_startup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2016-2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -70,8 +70,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "clear", no_argument, NULL, 'c' },
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("cs", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_takeownership.c
+++ b/tools/tpm2_takeownership.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018 Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -203,8 +203,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "clear",            no_argument,       NULL, 'c' },
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("o:e:l:O:E:L:c", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -203,8 +203,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {NULL,                   no_argument,       NULL, '\0'}
     };
 
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("H:P:o:c:S:L:F:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015-2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -271,9 +271,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
             { "key-context", 1, NULL, 'c' },
     };
 
-
+    tpm2_option_flags empty_flags = tpm2_option_flags_init(0);
     *opts = tpm2_options_new("k:g:m:D:rs:t:c:", ARRAY_LEN(topts), topts,
-            on_option, NULL);
+            on_option, NULL, empty_flags);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
Avoid the sapi initialization if tools request that
they don't need it via a flags argument to
tpm2_options_new();

Fixes: #737

Signed-off-by: William Roberts <william.c.roberts@intel.com>