### PR TITLE
tpm2_errata: mute the noises when more data is available

### DIFF
--- a/lib/tpm2_errata.c
+++ b/lib/tpm2_errata.c
@@ -165,9 +165,6 @@ void tpm2_errata_init(TSS2_SYS_CONTEXT *sapi_ctx) {
         LOG_ERR("Failed to GetCapability: capability: 0x%x, property: 0x%x, "
                 "TSS2_RC: 0x%x", TPM2_CAP_TPM_PROPERTIES, TPM2_PT_FIXED, rc);
         return;
-    } else if (more_data == YES) {
-        LOG_WARN("More data to be queried: capability: 0x%x, property: "
-                 "0x%x", TPM2_CAP_TPM_PROPERTIES, TPM2_PT_FIXED);
     }
 
     /* Distinguish current spec level 0 */


### PR DESCRIPTION
Infineon SLB9665 (PT_REV 1.16) is affected by the errata
"Sign/decrypt attribute encoding" and the related test case thus
needs -Z option.

However, the test cases print lots of noises about more-data-available
because this tpm chip always responds more data available when the
requesting property is PT_FIXED. Digging into the internal, PT_VAR is
implied as the potentially available data.

More worse, launching test.sh -Z causes each test case generating the
noises.

The errata logic only requires the first few fields from PT_FIXED so
the check for more_data can be ignored in order to mute the noises
when the errata is applied.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>